### PR TITLE
Add support for native mouse cursors in pyglet

### DIFF
--- a/imgui/integrations/pyglet.py
+++ b/imgui/integrations/pyglet.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import warnings
 from distutils.version import LooseVersion
 
-from pyglet.window import key, mouse
+from pyglet.window import key, mouse, Window
 import pyglet
 
 import imgui
@@ -36,6 +36,24 @@ class PygletMixin(object):
         key.Z: imgui.KEY_Z,
     }
 
+    MOUSE_CURSORS = {
+        imgui.MOUSE_CURSOR_ARROW: Window.CURSOR_DEFAULT,
+        imgui.MOUSE_CURSOR_TEXT_INPUT: Window.CURSOR_TEXT,
+        imgui.MOUSE_CURSOR_RESIZE_ALL: Window.CURSOR_SIZE,
+        imgui.MOUSE_CURSOR_RESIZE_NS: Window.CURSOR_SIZE_UP_DOWN,
+        imgui.MOUSE_CURSOR_RESIZE_EW: Window.CURSOR_SIZE_LEFT_RIGHT,
+        imgui.MOUSE_CURSOR_RESIZE_NESW: Window.CURSOR_SIZE_DOWN_LEFT,
+        imgui.MOUSE_CURSOR_RESIZE_NWSE: Window.CURSOR_SIZE_DOWN_RIGHT,
+        imgui.MOUSE_CURSOR_HAND: Window.CURSOR_HAND
+    }
+
+    def __init__(self):
+        super(PygletMixin, self).__init__()
+        self._cursor = -2
+        self._window = None
+        # Let Dear imgui know we have mouse cursor support
+        self.io.backend_flags |= imgui.BACKEND_HAS_MOUSE_CURSORS
+
     def _set_pixel_ratio(self, window):
         window_size = window.get_size()
         self.io.display_size = window_size
@@ -54,6 +72,7 @@ class PygletMixin(object):
 
 
     def _attach_callbacks(self, window):
+        self._window = window
         window.push_handlers(
             self.on_mouse_motion,
             self.on_key_press,
@@ -84,6 +103,20 @@ class PygletMixin(object):
                             key_pressed in (key.LALT, key.RALT)
         self.io.key_shift = mods & key.MOD_SHIFT or \
                             key_pressed in (key.LSHIFT, key.RSHIFT)
+
+    def _handle_mouse_cursor(self):
+        if self.io.config_flags & imgui.CONFIG_NO_MOUSE_CURSOR_CHARGE:
+            return
+
+        mouse_cursor = imgui.get_mouse_cursor()
+        window = self._window
+        if self._cursor != mouse_cursor:
+            self._cursor = mouse_cursor
+            if mouse_cursor == imgui.MOUSE_CURSOR_NONE:
+                window.set_mouse_visible(False)
+            else:
+                cursor = self.MOUSE_CURSORS.get(mouse_cursor)
+                window.set_mouse_cursor(window.get_system_mouse_cursor(cursor))
 
     def on_mouse_motion(self, x, y, dx, dy):
         self.io.mouse_pos = x, self.io.display_size.y - y
@@ -154,6 +187,10 @@ class PygletFixedPipelineRenderer(PygletMixin, FixedPipelineRenderer):
         self._map_keys()
         if attach_callbacks: self._attach_callbacks(window)
 
+    def render(self, draw_data):
+        super(PygletFixedPipelineRenderer, self).render(draw_data)
+        self._handle_mouse_cursor()
+
 
 class PygletProgrammablePipelineRenderer(PygletMixin, ProgrammablePipelineRenderer):
     def __init__(self, window, attach_callbacks = True):
@@ -161,6 +198,10 @@ class PygletProgrammablePipelineRenderer(PygletMixin, ProgrammablePipelineRender
         self._set_pixel_ratio(window)
         self._map_keys()
         if attach_callbacks: self._attach_callbacks(window)
+
+    def render(self, draw_data):
+        super(PygletProgrammablePipelineRenderer, self).render(draw_data)
+        self._handle_mouse_cursor()
 
 
 class PygletRenderer(PygletFixedPipelineRenderer):


### PR DESCRIPTION
To test this, open the demo dialog,
Expand 'Inputs, Navigation & Focus' (last item)
Expand the 'Mouse cursors' (last item)

Hover over the lines describing the cursors.

Only tested on Windows 10.


![image](https://user-images.githubusercontent.com/610685/108097425-62c3f180-7082-11eb-9ffa-60f13bbe2d8c.png)

![image](https://user-images.githubusercontent.com/610685/108097432-65bee200-7082-11eb-9cb8-db1756645abd.png)
