### PR TITLE
Update to use the docking branch of imgui-cpp

### DIFF
--- a/ansifeed-cpp/AnsiTextColored.cpp
+++ b/ansifeed-cpp/AnsiTextColored.cpp
@@ -515,7 +515,7 @@ namespace ImGui
                 if (line < text_end) {
                     ImRect line_rect(pos, pos + ImVec2(FLT_MAX, line_height));
                     while (line < text_end) {
-                        if (IsClippedEx(line_rect, 0, false))
+                        if (IsClippedEx(line_rect, 0))
                             break;
 
                         const char* line_end = (const char*)memchr(line, '\n', text_end - line);

--- a/imgui/cimgui.pxd
+++ b/imgui/cimgui.pxd
@@ -1017,7 +1017,6 @@ cdef extern from "imgui.h" namespace "ImGui":
             ImGuiFocusedFlags flags     # = 0
     ) except +
     ImDrawList* GetWindowDrawList() except +  # ✓
-    ImDrawList* GetOverlayDrawList() except + # ✓ # OBSOLETED in 1.69 (from Mar 2019)
     ImVec2 GetWindowPos() except +  # ✓
     ImVec2 GetWindowSize() except +  # ✓
     float GetWindowWidth() except +  # ✓
@@ -2111,7 +2110,6 @@ cdef extern from "imgui.h" namespace "ImGui":
     int GetFrameCount() except +  # ✗
     ImDrawList* GetBackgroundDrawList() except +  # ✓
     ImDrawList* GetForegroundDrawList() except +  # ✓
-    ImDrawList* GetOverlayDrawList() except +  # ✗ # OBSOLETED in 1.69 (from Mar 2019)
     ImDrawListSharedData* GetDrawListSharedData() except +  # ✗
     const char* GetStyleColorName(ImGuiCol idx) except +  # ✓
     void SetStateStorage(ImGuiStorage* storage) except +  # ✗

--- a/imgui/core.pyx
+++ b/imgui/core.pyx
@@ -186,7 +186,7 @@ COLOR_EDIT_PICKER_HUE_WHEEL = enums.ImGuiColorEditFlags_PickerHueWheel
 COLOR_EDIT_INPUT_RGB = enums.ImGuiColorEditFlags_InputRGB        
 COLOR_EDIT_INPUT_HSV = enums.ImGuiColorEditFlags_InputHSV        
 
-COLOR_EDIT_DEFAULT_OPTIONS = enums.ImGuiColorEditFlags__OptionsDefault
+COLOR_EDIT_DEFAULT_OPTIONS = enums.ImGuiColorEditFlags_DefaultOptions_
 
 # ==== TreeNode flags enum redefines ====
 TREE_NODE_NONE = enums.ImGuiTreeNodeFlags_None
@@ -3780,7 +3780,7 @@ def get_overlay_draw_list():
     .. wraps::
         ImDrawList* GetWindowDrawList()
     """
-    return _DrawList.from_ptr(cimgui.GetOverlayDrawList())
+    return _DrawList.from_ptr(cimgui.GetForegroundDrawList())
 
 
 def get_window_position():

--- a/imgui/enums.pxd
+++ b/imgui/enums.pxd
@@ -242,7 +242,7 @@ cdef extern from "imgui.h":
 
         # Defaults Options. You can set application defaults using SetColorEditOptions(). The intent is that you probably don't want to
         # override them in most of your calls. Let the user choose via the option menu and/or call SetColorEditOptions() once during startup.
-        ImGuiColorEditFlags__OptionsDefault = ImGuiColorEditFlags_Uint8 | ImGuiColorEditFlags_DisplayRGB | ImGuiColorEditFlags_InputRGB | ImGuiColorEditFlags_PickerHueBar,
+        ImGuiColorEditFlags_DefaultOptions_ = ImGuiColorEditFlags_Uint8 | ImGuiColorEditFlags_DisplayRGB | ImGuiColorEditFlags_InputRGB | ImGuiColorEditFlags_PickerHueBar,
 
 
     ctypedef enum ImGuiSliderFlags_:

--- a/imgui/enums_internal.pxd
+++ b/imgui/enums_internal.pxd
@@ -10,7 +10,6 @@ cdef extern from "imgui_internal.h":
         ImGuiItemFlags_SelectableDontClosePopup # false    # MenuItem/Selectable() automatically closes current Popup window
         ImGuiItemFlags_MixedValue               # false    # [BETA] Represent a mixed/indeterminate value, generally multi-selection where values differ. Currently only supported by Checkbox() (later should support all sorts of widgets)
         ImGuiItemFlags_ReadOnly                 # false    # [ALPHA] Allow hovering interactions but underlying value is not changed.
-        ImGuiItemFlags_Default_                 #
         
         
     ctypedef enum ImGuiItemStatusFlags_:
@@ -34,7 +33,7 @@ cdef extern from "imgui_internal.h":
         ImGuiButtonFlags_FlattenChildren        # allow interactions even if a child window is overlapping
         ImGuiButtonFlags_AllowItemOverlap       # require previous frame HoveredId to either match id or be null before being usable, use along with SetItemAllowOverlap()
         ImGuiButtonFlags_DontClosePopups        # disable automatically closing parent popup on press // [UNUSED]
-        ImGuiButtonFlags_Disabled               # disable interactions
+        #ImGuiButtonFlags_Disabled               # disable interactions -> use BeginDisabled() or ImGuiItemFlags_Disabled
         ImGuiButtonFlags_AlignTextBaseLine      # vertically align button to match text baseline - ButtonEx() only // FIXME: Should be removed and handled by SmallButton(), not possible currently because of DC.CursorPosPrevLine
         ImGuiButtonFlags_NoKeyModifiers         # disable mouse interaction if a key modifier is held
         ImGuiButtonFlags_NoHoldingActiveId      # don't set ActiveId while holding the mouse (ImGuiButtonFlags_PressedOnClick only)
@@ -135,12 +134,7 @@ cdef extern from "imgui_internal.h":
         ImGuiNavMoveFlags_WrapY                 # This is not super useful for provided for completeness
         ImGuiNavMoveFlags_AllowCurrentNavId     # Allow scoring and considering the current NavId as a move target candidate. This is used when the move source is offset (e.g. pressing PageDown actually needs to send a Up move request, if we are pressing PageDown from the bottom-most item we need to stay in place)
         ImGuiNavMoveFlags_AlsoScoreVisibleSet   # Store alternate result in NavMoveResultLocalVisibleSet that only comprise elements that are already fully visible.
-        ImGuiNavMoveFlags_ScrollToEdge          #
-    
-    ctypedef enum ImGuiNavForward:
-        ImGuiNavForward_None
-        ImGuiNavForward_ForwardQueued
-        ImGuiNavForward_ForwardActive
+        ImGuiNavMoveFlags_ScrollToEdgeY         # Force scrolling to min/max (used by Home/End) // FIXME-NAV: Aim to remove or reword, probably
     
     ctypedef enum ImGuiNavLayer:
         ImGuiNavLayer_Main  # Main scrolling layer

--- a/imgui/internal.pxd
+++ b/imgui/internal.pxd
@@ -75,7 +75,6 @@ cdef extern from "imgui_internal.h":
     ctypedef int ImGuiPlotType
     ctypedef int ImGuiInputSource
     ctypedef int ImGuiInputReadMode
-    ctypedef int ImGuiNavForward
     ctypedef int ImGuiNavLayer
     ctypedef int ImGuiPopupPositionPolicy
     ctypedef void (*ImGuiErrorLogCallback)(void* user_data, const char* fmt, ...)
@@ -280,7 +279,7 @@ cdef extern from "imgui_internal.h" namespace "ImGui":
         const ImRect* nav_bb            # = NULL
     ) except +
     bool ItemHoverable(const ImRect& bb, ImGuiID id) except + # ?
-    bool IsClippedEx(const ImRect& bb, ImGuiID id, bool clip_even_when_logged) except + # ?
+    bool IsClippedEx(const ImRect& bb, ImGuiID id) except + # ?
     void SetLastItemData(ImGuiWindow* window, ImGuiID item_id, ImGuiItemStatusFlags status_flags, const ImRect& item_rect) except + # ?
     bool FocusableItemRegister(ImGuiWindow* window, ImGuiID id) except + # ?
     void FocusableItemUnregister(ImGuiWindow* window) except + # ?

--- a/imgui/internal.pyx
+++ b/imgui/internal.pyx
@@ -28,7 +28,6 @@ ITEM_NO_NAV_DEFAULT_FOCUS = enums_internal.ImGuiItemFlags_NoNavDefaultFocus
 ITEM_SELECTABLE_DONT_CLOSE_POPUP = enums_internal.ImGuiItemFlags_SelectableDontClosePopup 
 ITEM_MIXED_VALUE = enums_internal.ImGuiItemFlags_MixedValue               
 ITEM_READ_ONLY = enums_internal.ImGuiItemFlags_ReadOnly                 
-ITEM_DEFAULT = enums_internal.ImGuiItemFlags_Default_                 
 
 # Item Status Flags
 ITEM_STATUS_NONE = enums_internal.ImGuiItemStatusFlags_None
@@ -51,7 +50,7 @@ BUTTON_REPEAT = enums_internal.ImGuiButtonFlags_Repeat
 BUTTON_FLATTEN_CHILDREN = enums_internal.ImGuiButtonFlags_FlattenChildren
 BUTTON_ALLOW_ITEM_OVERLAP = enums_internal.ImGuiButtonFlags_AllowItemOverlap
 BUTTON_DONT_CLOSE_POPUPS = enums_internal.ImGuiButtonFlags_DontClosePopups
-BUTTON_DISABLED = enums_internal.ImGuiButtonFlags_Disabled
+#BUTTON_DISABLED = enums_internal.ImGuiButtonFlags_Disabled
 BUTTON_ALIGN_TEXT_BASE_LINE = enums_internal.ImGuiButtonFlags_AlignTextBaseLine
 BUTTON_NO_KEY_MODIFIERS = enums_internal.ImGuiButtonFlags_NoKeyModifiers
 BUTTON_NO_HOLDING_ACTIVE_ID = enums_internal.ImGuiButtonFlags_NoHoldingActiveId
@@ -147,12 +146,7 @@ NAV_MOVE_WRAP_X = enums_internal.ImGuiNavMoveFlags_WrapX
 NAV_MOVE_WRAP_Y = enums_internal.ImGuiNavMoveFlags_WrapY
 NAV_MOVE_ALLOW_CURRENT_NAV_ID = enums_internal.ImGuiNavMoveFlags_AllowCurrentNavId
 NAV_MOVE_ALSO_SCORE_VISIBLE_SET = enums_internal.ImGuiNavMoveFlags_AlsoScoreVisibleSet
-NAV_MOVE_SCROLL_TO_EDGE = enums_internal.ImGuiNavMoveFlags_ScrollToEdge
-
-# Nav Forward
-NAV_FORWARD_NONE = enums_internal.ImGuiNavForward_None
-NAV_FORWARD_FORWARD_QUEUED = enums_internal.ImGuiNavForward_ForwardQueued
-NAV_FORWARD_FORWARD_ACTIVE = enums_internal.ImGuiNavForward_ForwardActive
+NAV_MOVE_SCROLL_TO_EDGE = enums_internal.ImGuiNavMoveFlags_ScrollToEdgeY
 
 # Nav Layer
 NAV_LAYER_MAIN = enums_internal.ImGuiNavLayer_Main


### PR DESCRIPTION
This is an update to the `version-2.0` branch that is a minimal set of changes to allow building against the `docking` branch of imgui-cpp. This is enough to build, and to run the demo docking example.

Relates to issue #227