### PR TITLE
Feature/DLL (study)

### DIFF
--- a/imgui/__init__.py
+++ b/imgui/__init__.py
@@ -2,12 +2,12 @@
 VERSION = (2, 0, 0)  # PEP 386
 __version__ = ".".join([str(x) for x in VERSION])
 
-from imgui.core import *  # noqa
-from imgui import core
-from imgui.extra import *  # noqa
-from imgui import extra
-from imgui import _compat
-from imgui import internal
+from .core import *  # noqa
+from . import core
+from .extra import *  # noqa
+from . import extra
+from . import _compat
+from . import internal
 
 # TODO: Complete and correcte doc text for ImGui v1.79
 

--- a/imgui/common.pyx
+++ b/imgui/common.pyx
@@ -1,6 +1,3 @@
-# distutils: language = c++
-# distutils: sources = imgui-cpp/imgui.cpp imgui-cpp/imgui_draw.cpp imgui-cpp/imgui_demo.cpp imgui-cpp/imgui_widgets.cpp imgui-cpp/imgui_tables.cpp config-cpp/py_imconfig.cpp
-# distutils: include_dirs = imgui-cpp ansifeed-cpp
 # cython: embedsignature=True
 # cython: linetrace=True
 

--- a/imgui/core.pyx
+++ b/imgui/core.pyx
@@ -1,6 +1,3 @@
-# distutils: language = c++
-# distutils: sources = imgui-cpp/imgui.cpp imgui-cpp/imgui_draw.cpp imgui-cpp/imgui_demo.cpp imgui-cpp/imgui_widgets.cpp imgui-cpp/imgui_tables.cpp config-cpp/py_imconfig.cpp
-# distutils: include_dirs = imgui-cpp ansifeed-cpp
 # cython: embedsignature=True
 """
 
@@ -40,7 +37,7 @@ cimport internal
 from cpython.version cimport PY_MAJOR_VERSION
 
 # todo: find a way to cimport this directly from imgui.h
-DEF TARGET_IMGUI_VERSION = (1, 79)
+DEF TARGET_IMGUI_VERSION = (1, 82)
 
 cdef unsigned short* _LATIN_ALL = [0x0020, 0x024F , 0]
 

--- a/imgui/internal.pyx
+++ b/imgui/internal.pyx
@@ -1,6 +1,3 @@
-# distutils: language = c++
-# distutils: sources = imgui-cpp/imgui.cpp imgui-cpp/imgui_draw.cpp imgui-cpp/imgui_demo.cpp imgui-cpp/imgui_widgets.cpp imgui-cpp/imgui_tables.cpp config-cpp/py_imconfig.cpp
-# distutils: include_dirs = imgui-cpp ansifeed-cpp
 # cython: embedsignature=True
 
 import cython


### PR DESCRIPTION
Starting the DLL feature as discussed in other PRs and issues.

Starting from @pvallet's proposal: #229, thanks!

The idea is to check whether it is doable in the long run to not compile *DearImGui* directly inside pyimgui but as an independent DLL. This would solve the code duplication problem of submodules such as `internal` and should offer the possibility to develop addons such as `pyimplot` or `pyimnode` without having to bake them inside `pyimgui`. 

Objectives of this branch are to
* Propose a version of `pyimgui` that compile *DearImGui* as an external DLL and uses it.
* Measure its performance against the statically linked version
* Propose a branch from which prototypes of addons may be developed in order to understand what would be the best setup for external developers to extend pyimgui functionalities.

Big thanks to @Inventor-Mentor for his insight and thoughts on that matter. See his post for more information: https://github.com/pyimgui/pyimgui/pull/244#issuecomment-967939550

 