### PR TITLE
Add keepalive cache to keep objects stored as void* from being gc'ed.

### DIFF
--- a/tests/test_graphics_mem_safety.py
+++ b/tests/test_graphics_mem_safety.py
@@ -25,7 +25,7 @@ def test_texture_id_int_reference(context, io):
     # See issue #248 (https://github.com/pyimgui/pyimgui/issues/248)
 
     texture_id = 0
-    for i in range(0,10000):
+    for i in range(0, 1000, 50):
         imgui.new_frame()
 
         imgui.begin("tests")
@@ -43,8 +43,6 @@ def test_texture_id_int_reference(context, io):
         draw_data = imgui.get_draw_data()
         for commands in draw_data.commands_lists:
             for command in commands.commands:
-                if type(command.texture_id) is imgui.core._DrawList:
-                    continue
                 assert type(command.texture_id) is int
 
 def test_texture_id_keep_type(context, io):

--- a/tests/test_graphics_mem_safety.py
+++ b/tests/test_graphics_mem_safety.py
@@ -1,0 +1,65 @@
+"""Note: This tests are potential crashers (may result in segfaults)"""
+import pytest
+import imgui
+
+@pytest.fixture
+def context():
+    return imgui.create_context()
+
+@pytest.fixture
+def io():
+    # setup io
+    io = imgui.get_io()
+    io.delta_time = 1.0 / 60.0
+    io.display_size = 300, 300
+
+    # setup default font
+    io.fonts.get_tex_data_as_rgba32()
+    io.fonts.add_font_default()
+    io.fonts.texture_id = 42  # set any texture ID to avoid segfaults
+
+    return io
+
+def test_texture_id_int_reference(context, io):
+
+    # See issue #248 (https://github.com/pyimgui/pyimgui/issues/248)
+
+    texture_id = 0
+    for i in range(0,10000):
+        imgui.new_frame()
+
+        imgui.begin("tests")
+        io.fonts.texture_id = texture_id
+        imgui.image(texture_id, 640, 480)
+        imgui.image_button(texture_id, 200, 50)
+        draw_list = imgui.get_background_draw_list()
+        draw_list.add_image(texture_id, (20, 35), (180, 80))
+        imgui.end()
+
+        texture_id += 1
+
+        imgui.render()
+        
+        draw_data = imgui.get_draw_data()
+        for commands in draw_data.commands_lists:
+            for command in commands.commands:
+                if type(command.texture_id) is imgui.core._DrawList:
+                    continue
+                assert type(command.texture_id) is int
+
+def test_texture_id_keep_type(context, io):
+
+    texture_id = { 'dummy':42 }
+
+    imgui.new_frame()
+    imgui.image(texture_id, 640, 480)
+    imgui.render()
+    draw_data = imgui.get_draw_data()
+    for commands in draw_data.commands_lists:
+        for command in commands.commands:
+
+            # Skip font atlas texture id
+            if command.texture_id == io.fonts.texture_id:
+                continue
+
+            assert type(command.texture_id) == type(texture_id)    


### PR DESCRIPTION
Fixes: https://github.com/pyimgui/pyimgui/issues/248

Here is an alternative fix for #248. This approach keeps a cache of objects stored as void pointers so that the corresponding Python objects are not garbage collected before they are needed. The cache is cleared every new_frame(). The cache is not threadsafe, but I assume pyimgui does not intend to be threadsafe. The cache could cause memory use to increase without bound if the user does something nonsensical, e.g.

```python3
atlas = ... #some _FontAtlas object
while True:
    atlas.texture_id = 0 # copies of 0 will keep getting added to the cache until new_frame() is called.
```

I chose the cache to be a list because it would be the fastest and easiest option.
Another option would be to use a dict of id(object) -> object, which would be slower but not suffer from the memory issue above.