### PR TITLE
add imgui.dockspace()

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -105,8 +105,8 @@ class DocItem(pytest.Item):
         io.display_size = 300, 300
 
         # setup default font
-        io.fonts.get_tex_data_as_rgba32()
         io.fonts.add_font_default()
+        io.fonts.get_tex_data_as_rgba32()
         io.fonts.texture_id = 0  # set any texture ID to avoid segfaults
 
         imgui.new_frame()

--- a/doc/examples/integrations_glfw3_docking.py
+++ b/doc/examples/integrations_glfw3_docking.py
@@ -1,0 +1,138 @@
+# -*- coding: utf-8 -*-
+import glfw
+import OpenGL.GL as gl
+
+import imgui
+from imgui.integrations.glfw import GlfwRenderer
+from testwindow import show_test_window
+
+
+def docking_space(name: str):
+    flags = (imgui.WINDOW_MENU_BAR 
+    | imgui.WINDOW_NO_DOCKING 
+    # | imgui.WINDOW_NO_BACKGROUND
+    | imgui.WINDOW_NO_TITLE_BAR
+    | imgui.WINDOW_NO_COLLAPSE
+    | imgui.WINDOW_NO_RESIZE
+    | imgui.WINDOW_NO_MOVE
+    | imgui.WINDOW_NO_BRING_TO_FRONT_ON_FOCUS
+    | imgui.WINDOW_NO_NAV_FOCUS
+    )
+
+    viewport = imgui.get_main_viewport()
+    x, y = viewport.pos
+    w, h = viewport.size
+    imgui.set_next_window_position(x, y)
+    imgui.set_next_window_size(w, h)
+    # imgui.set_next_window_viewport(viewport.id)
+    imgui.push_style_var(imgui.STYLE_WINDOW_BORDERSIZE, 0.0)
+    imgui.push_style_var(imgui.STYLE_WINDOW_ROUNDING, 0.0)
+
+    # When using ImGuiDockNodeFlags_PassthruCentralNode, DockSpace() will render our background and handle the pass-thru hole, so we ask Begin() to not render a background.
+    # local window_flags = self.window_flags
+    # if bit.band(self.dockspace_flags, ) ~= 0 then
+    #     window_flags = bit.bor(window_flags, const.ImGuiWindowFlags_.NoBackground)
+    # end
+
+    # Important: note that we proceed even if Begin() returns false (aka window is collapsed).
+    # This is because we want to keep our DockSpace() active. If a DockSpace() is inactive,
+    # all active windows docked into it will lose their parent and become undocked.
+    # We cannot preserve the docking relationship between an active window and an inactive docking, otherwise
+    # any change of dockspace/settings would lead to windows being stuck in limbo and never being visible.
+    imgui.push_style_var(imgui.STYLE_WINDOW_PADDING, (0, 0))
+    imgui.begin(name, None, flags)
+    imgui.pop_style_var()
+    imgui.pop_style_var(2)
+
+    # DockSpace
+    dockspace_id = imgui.get_id(name)
+    imgui.dockspace(dockspace_id, (0, 0), imgui.DOCKNODE_PASSTHRU_CENTRAL_NODE)
+
+    imgui.end()
+
+
+def main():
+    imgui.create_context()
+    io = imgui.get_io()
+    io.config_flags |= imgui.CONFIG_DOCKING_ENABLE
+
+    window = impl_glfw_init()
+    impl = GlfwRenderer(window)
+
+    show_custom_window = True
+
+    while not glfw.window_should_close(window):
+        glfw.poll_events()
+        impl.process_inputs()
+
+        imgui.new_frame()
+
+        docking_space('docking_space')
+
+        if imgui.begin_main_menu_bar():
+            if imgui.begin_menu("File", True):
+
+                clicked_quit, selected_quit = imgui.menu_item(
+                    "Quit", 'Cmd+Q', False, True
+                )
+
+                if clicked_quit:
+                    exit(1)
+
+                imgui.end_menu()
+            imgui.end_main_menu_bar()
+
+        if show_custom_window:
+            is_expand, show_custom_window = imgui.begin("Custom window", True)
+            if is_expand:
+                imgui.text("Bar")
+                imgui.text_ansi("B\033[31marA\033[mnsi ")
+                imgui.text_ansi_colored("Eg\033[31mgAn\033[msi ", 0.2, 1., 0.)
+                imgui.extra.text_ansi_colored("Eggs", 0.2, 1., 0.)
+            imgui.end()
+
+        show_test_window()
+        # imgui.show_test_window()
+
+        gl.glClearColor(1., 1., 1., 1)
+        gl.glClear(gl.GL_COLOR_BUFFER_BIT)
+
+        imgui.render()
+        impl.render(imgui.get_draw_data())
+        glfw.swap_buffers(window)
+
+    impl.shutdown()
+    glfw.terminate()
+
+
+def impl_glfw_init():
+    width, height = 1280, 720
+    window_name = "minimal ImGui/GLFW3 example"
+
+    if not glfw.init():
+        print("Could not initialize OpenGL context")
+        exit(1)
+
+    # OS X supports only forward-compatible core profiles from 3.2
+    glfw.window_hint(glfw.CONTEXT_VERSION_MAJOR, 3)
+    glfw.window_hint(glfw.CONTEXT_VERSION_MINOR, 3)
+    glfw.window_hint(glfw.OPENGL_PROFILE, glfw.OPENGL_CORE_PROFILE)
+
+    glfw.window_hint(glfw.OPENGL_FORWARD_COMPAT, gl.GL_TRUE)
+
+    # Create a windowed mode window and its OpenGL context
+    window = glfw.create_window(
+        int(width), int(height), window_name, None, None
+    )
+    glfw.make_context_current(window)
+
+    if not window:
+        glfw.terminate()
+        print("Could not initialize Window")
+        exit(1)
+
+    return window
+
+
+if __name__ == "__main__":
+    main()

--- a/imgui/__init__.py
+++ b/imgui/__init__.py
@@ -220,6 +220,8 @@ WINDOW_NO_NAV_INPUTS = core.WINDOW_NO_NAV_INPUTS
 WINDOW_NO_NAV_FOCUS = core.WINDOW_NO_NAV_FOCUS
 #: Append '*' to title without affecting the ID, as a convenience to avoid using the ### operator. When used in a tab/docking context, tab is selected on closure and closure is deferred by one frame to allow code to cancel the closure (with a confirmation popup, etc.) without flicker.
 WINDOW_UNSAVED_DOCUMENT = core.WINDOW_UNSAVED_DOCUMENT
+#: Disable docking of this window
+WINDOW_NO_DOCKING = core.WINDOW_NO_DOCKING
 #: Shortcut: ``imgui.WINDOW_NO_NAV_INPUTS | imgui.WINDOW_NO_NAV_FOCUS``.
 WINDOW_NO_NAV = core.WINDOW_NO_NAV
 #: Shortcut: ``imgui.WINDOW_NO_TITLE_BAR | imgui.WINDOW_NO_RESIZE | imgui.WINDOW_NO_SCROLLBAR | imgui.WINDOW_NO_COLLAPSE``.
@@ -656,6 +658,22 @@ HOVERED_RECT_ONLY = core.HOVERED_ALLOW_WHEN_BLOCKED_BY_POPUP | core.HOVERED_ALLO
 #: Shortcut: ``imgui.HOVERED_ROOT_WINDOW | imgui.HOVERED_CHILD_WINDOWS``.
 HOVERED_ROOT_AND_CHILD_WINDOWS = core.HOVERED_ROOT_WINDOW | core.HOVERED_CHILD_WINDOWS
 
+# === Flags for imgui.dockspace(), shared/inherited by child nodes. (redefines for autodoc)
+#: (Some flags can be applied to individual nodes directly)
+DOCKNODE_NONE = core.DOCKNODE_NONE
+#: Shared       # Don't display the dockspace node but keep it alive. Windows docked into this dockspace node won't be undocked.
+DOCKNODE_KEEPALIVE_ONLY = core.DOCKNODE_KEEPALIVE_ONLY
+#: Shared       # Disable docking inside the Central Node, which will be always kept empty.
+DOCKNODE_NO_DOCKING_IN_CENTRAL_NODE = core.DOCKNODE_NO_DOCKING_IN_CENTRAL_NODE
+#: Shared       # Enable passthru dockspace: 1) dockspace() will render a COLOR_WINDOW_BACKGROUND background covering everything excepted the Central Node when empty. Meaning the host window should probably use set_next_window_bg_alpha(0.0f) prior to begin() when using this. 2) When Central Node is empty: let inputs pass-through + won't display a DockingEmptyBg background. See demo for details.
+DOCKNODE_PASSTHRU_CENTRAL_NODE = core.DOCKNODE_PASSTHRU_CENTRAL_NODE
+#: Shared/Local # Disable splitting the node into smaller nodes. Useful e.g. when embedding dockspaces into a main root one (the root one may have splitting disabled to reduce confusion). Note: when turned off, existing splits will be preserved.
+DOCKNODE_NO_SPLIT = core.DOCKNODE_NO_SPLIT
+#: Shared/Local # Disable resizing node using the splitter/separators. Useful with programmatically setup dockspaces.
+DOCKNODE_NO_RESIZE = core.DOCKNODE_NO_RESIZE
+#: Shared/Local # Tab bar will automatically hide when there is a single window in the dock node.
+DOCKNODE_AUTO_HIDE_TABBAR = core.DOCKNODE_AUTO_HIDE_TABBAR
+
 # === Drag Drop flag constants (redefines for autodoc)
 DRAG_DROP_NONE = core.DRAG_DROP_NONE
 #: By default, a successful call to BeginDragDropSource opens a tooltip
@@ -839,6 +857,8 @@ CONFIG_NAV_ENABLE_SET_MOUSE_POS = core.CONFIG_NAV_ENABLE_SET_MOUSE_POS
 CONFIG_NAV_NO_CAPTURE_KEYBOARD = core.CONFIG_NAV_NO_CAPTURE_KEYBOARD
 CONFIG_NO_MOUSE = core.CONFIG_NO_MOUSE
 CONFIG_NO_MOUSE_CURSOR_CHANGE = core.CONFIG_NO_MOUSE_CURSOR_CHANGE
+#: Docking enable flags.
+CONFIG_DOCKING_ENABLE = core.CONFIG_DOCKING_ENABLE
 CONFIG_IS_RGB = core.CONFIG_IS_RGB
 CONFIG_IS_TOUCH_SCREEN = core.CONFIG_IS_TOUCH_SCREEN
 

--- a/imgui/cimgui.pxd
+++ b/imgui/cimgui.pxd
@@ -2016,7 +2016,7 @@ cdef extern from "imgui.h" namespace "ImGui":
     
     # ====
     # create an explicit dock node _within_ an existing window. See Docking demo for details.
-    ImGuiID DockSpace(ImGuiID id, const ImVec2& size, ImGuiDockNodeFlags flags, const void* window_class)
+    ImGuiID DockSpace(ImGuiID id, const ImVec2& size, ImGuiDockNodeFlags flags, const void* window_class) except + # ✓
 
     # ====
     # Logging/Capture

--- a/imgui/cimgui.pxd
+++ b/imgui/cimgui.pxd
@@ -79,6 +79,7 @@ cdef extern from "imgui.h":
     ctypedef int ImGuiTableRowFlags
     ctypedef int ImGuiTreeNodeFlags
     ctypedef int ImGuiWindowFlags
+    ctypedef int ImGuiDockNodeFlags
     # ctypedef int ImGuiColumnsFlags # DEPRECIATED
 
     # ====
@@ -2013,6 +2014,10 @@ cdef extern from "imgui.h" namespace "ImGui":
     ) except +
     void SetTabItemClosed(const char* tab_or_docked_window_label) except + # ✓
     
+    # ====
+    # create an explicit dock node _within_ an existing window. See Docking demo for details.
+    ImGuiID DockSpace(ImGuiID id, const ImVec2& size, ImGuiDockNodeFlags flags, const void* window_class)
+
     # ====
     # Logging/Capture
     # Logging: all text output from interface is redirected to

--- a/imgui/core.pyx
+++ b/imgui/core.pyx
@@ -10313,8 +10313,20 @@ def set_tab_item_closed(str tab_or_docked_window_label):
     cimgui.SetTabItemClosed(_bytes(tab_or_docked_window_label))
 
 def dockspace(cimgui.ImGuiID id, tuple size=(0, 0), cimgui.ImGuiDockNodeFlags flags=0):
-    """
-    create an explicit dock node _within_ an existing window. See Docking demo for details.    
+    """Create an explicit dockspace node within an existing window. Also expose dock node flags and creates a CentralNode by default.
+    The Central Node is always displayed even when empty and shrink/extend according to the requested size of its neighbors.
+    dockspace() needs to be submitted _before_ any window they can host. If you use a dockspace, submit it early in your app.
+
+    Args:
+        id (ImGuiID): Identifier
+        size (tuple): Size
+        flags (ImGuiDockNodeFlags): DockNode flags.
+        
+    Returns:
+        ImGuiID: Identifier
+
+    .. wraps::
+        ImGuiID DockSpace(ImGuiID id, const ImVec2& size, ImGuiDockNodeFlags flags, const void* window_class)
     """
     return cimgui.DockSpace(id, _cast_tuple_ImVec2(size), flags, NULL)
 

--- a/imgui/core.pyx
+++ b/imgui/core.pyx
@@ -155,6 +155,7 @@ WINDOW_ALWAYS_USE_WINDOW_PADDING = enums.ImGuiWindowFlags_AlwaysUseWindowPadding
 WINDOW_NO_NAV_INPUTS = enums.ImGuiWindowFlags_NoNavInputs
 WINDOW_NO_NAV_FOCUS = enums.ImGuiWindowFlags_NoNavFocus
 WINDOW_UNSAVED_DOCUMENT = enums.ImGuiWindowFlags_UnsavedDocument
+WINDOW_NO_DOCKING = enums.ImGuiWindowFlags_NoDocking
 WINDOW_NO_NAV = enums.ImGuiWindowFlags_NoNav
 WINDOW_NO_DECORATION = enums.ImGuiWindowFlags_NoDecoration
 WINDOW_NO_INPUTS = enums.ImGuiWindowFlags_NoInputs
@@ -363,6 +364,16 @@ HOVERED_ALLOW_WHEN_DISABLED = enums.ImGuiHoveredFlags_AllowWhenDisabled
 HOVERED_RECT_ONLY = enums.ImGuiHoveredFlags_RectOnly
 HOVERED_ROOT_AND_CHILD_WINDOWS = enums.ImGuiHoveredFlags_RootAndChildWindows
 
+# === Flags for ImGui::DockSpace(), shared/inherited by child nodes.===
+DOCKNODE_NONE = enums.ImGuiDockNodeFlags_None
+DOCKNODE_KEEPALIVE_ONLY = enums.ImGuiDockNodeFlags_KeepAliveOnly
+#ImGuiDockNodeFlags_NoCentralNode
+DOCKNODE_NO_DOCKING_IN_CENTRAL_NODE = enums.ImGuiDockNodeFlags_NoDockingInCentralNode
+DOCKNODE_PASSTHRU_CENTRAL_NODE = enums.ImGuiDockNodeFlags_PassthruCentralNode
+DOCKNODE_NO_SPLIT = enums.ImGuiDockNodeFlags_NoSplit
+DOCKNODE_NO_RESIZE = enums.ImGuiDockNodeFlags_NoResize
+DOCKNODE_AUTO_HIDE_TABBAR = enums.ImGuiDockNodeFlags_AutoHideTabBar
+
 # === Drag Drop flag enum redefines ====
 DRAG_DROP_NONE = enums.ImGuiDragDropFlags_None
 DRAG_DROP_SOURCE_NO_PREVIEW_TOOLTIP = enums.ImGuiDragDropFlags_SourceNoPreviewTooltip
@@ -543,6 +554,7 @@ CONFIG_NAV_ENABLE_SET_MOUSE_POS = enums.ImGuiConfigFlags_.ImGuiConfigFlags_NavEn
 CONFIG_NAV_NO_CAPTURE_KEYBOARD = enums.ImGuiConfigFlags_.ImGuiConfigFlags_NavNoCaptureKeyboard
 CONFIG_NO_MOUSE = enums.ImGuiConfigFlags_.ImGuiConfigFlags_NoMouse
 CONFIG_NO_MOUSE_CURSOR_CHANGE = enums.ImGuiConfigFlags_.ImGuiConfigFlags_NoMouseCursorChange
+CONFIG_DOCKING_ENABLE = enums.ImGuiConfigFlags_.ImGuiConfigFlags_DockingEnable
 CONFIG_IS_RGB = enums.ImGuiConfigFlags_.ImGuiConfigFlags_IsSRGB
 CONFIG_IS_TOUCH_SCREEN = enums.ImGuiConfigFlags_.ImGuiConfigFlags_IsTouchScreen
 
@@ -10300,6 +10312,12 @@ def set_tab_item_closed(str tab_or_docked_window_label):
     """
     cimgui.SetTabItemClosed(_bytes(tab_or_docked_window_label))
 
+def dockspace(cimgui.ImGuiID id, tuple size=(0, 0), cimgui.ImGuiDockNodeFlags flags=0):
+    """
+    create an explicit dock node _within_ an existing window. See Docking demo for details.    
+    """
+    return cimgui.DockSpace(id, _cast_tuple_ImVec2(size), flags, NULL)
+
 def begin_drag_drop_source(cimgui.ImGuiDragDropFlags flags=0):
     """Set the current item as a drag and drop source. If this return True, you
     can call :func:`set_drag_drop_payload` and :func:`end_drag_drop_source`.
@@ -10749,6 +10767,9 @@ def pop_id():
         PopID()
     """
     cimgui.PopID()
+
+def get_id(str begin):
+    return cimgui.GetID(_bytes(begin))
 
 def _ansifeed_text_ansi(str text):
     """Add ANSI-escape-formatted text to current widget stack.

--- a/imgui/core.pyx
+++ b/imgui/core.pyx
@@ -10768,8 +10768,17 @@ def pop_id():
     """
     cimgui.PopID()
 
-def get_id(str begin):
-    return cimgui.GetID(_bytes(begin))
+def get_id(str str_id):
+    """Calculate unique ID (hash of whole ID stack + given parameter). 
+    e.g. if you want to query into ImGuiStorage yourself
+
+    Args:
+        str_id (str): String Id
+    
+    wraps::
+        GetID(const char* str_id)
+    """
+    return cimgui.GetID(_bytes(str_id))
 
 def _ansifeed_text_ansi(str text):
     """Add ANSI-escape-formatted text to current widget stack.

--- a/imgui/enums.pxd
+++ b/imgui/enums.pxd
@@ -60,6 +60,7 @@ cdef extern from "imgui.h":
         ImGuiConfigFlags_NavNoCaptureKeyboard   # Instruct navigation to not set the io.WantCaptureKeyboard flag when io.NavActive is set.
         ImGuiConfigFlags_NoMouse                # Instruct imgui to clear mouse position/buttons in NewFrame(). This allows ignoring the mouse information set by the backend.
         ImGuiConfigFlags_NoMouseCursorChange    # Instruct backend to not alter mouse cursor shape and visibility. Use if the backend cursor changes are interfering with yours and you don't want to use SetMouseCursor() to change mouse cursor. You may want to honor requests from imgui by reading GetMouseCursor() yourself instead.
+        ImGuiConfigFlags_DockingEnable
 
         # User storage (to allow your backend/engine to communicate to code that may be shared between multiple projects. Those flags are not used by core Dear ImGui)
         ImGuiConfigFlags_IsSRGB                 # Application is SRGB-aware.
@@ -207,6 +208,7 @@ cdef extern from "imgui.h":
         ImGuiWindowFlags_NoNavInputs             # No gamepad/keyboard navigation within the window
         ImGuiWindowFlags_NoNavFocus              # No focusing toward this window with gamepad/keyboard navigation (e.g. skipped by CTRL+TAB)
         ImGuiWindowFlags_UnsavedDocument         # Append '*' to title without affecting the ID, as a convenience to avoid using the ### operator. When used in a tab/docking context, tab is selected on closure and closure is deferred by one frame to allow code to cancel the closure (with a confirmation popup, etc.) without flicker.
+        ImGuiWindowFlags_NoDocking               # Disable docking of this window
         ImGuiWindowFlags_NoNav                  = ImGuiWindowFlags_NoNavInputs | ImGuiWindowFlags_NoNavFocus,
         ImGuiWindowFlags_NoDecoration           = ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoCollapse,
         ImGuiWindowFlags_NoInputs               = ImGuiWindowFlags_NoMouseInputs | ImGuiWindowFlags_NoNavInputs | ImGuiWindowFlags_NoNavFocus,
@@ -443,6 +445,17 @@ cdef extern from "imgui.h":
         ImGuiHoveredFlags_AllowWhenDisabled             # Return true even if the item is disabled
         ImGuiHoveredFlags_RectOnly                      = ImGuiHoveredFlags_AllowWhenBlockedByPopup | ImGuiHoveredFlags_AllowWhenBlockedByActiveItem | ImGuiHoveredFlags_AllowWhenOverlapped,
         ImGuiHoveredFlags_RootAndChildWindows           = ImGuiHoveredFlags_RootWindow | ImGuiHoveredFlags_ChildWindows
+
+
+    ctypedef enum ImGuiDockNodeFlags_:
+        ImGuiDockNodeFlags_None                         
+        ImGuiDockNodeFlags_KeepAliveOnly                # Shared       // Don't display the dockspace node but keep it alive. Windows docked into this dockspace node won't be undocked.
+        #ImGuiDockNodeFlags_NoCentralNode               # Shared       // Disable Central Node (the node which can stay empty)
+        ImGuiDockNodeFlags_NoDockingInCentralNode       # Shared       // Disable docking inside the Central Node, which will be always kept empty.
+        ImGuiDockNodeFlags_PassthruCentralNode          # Shared       // Enable passthru dockspace: 1) DockSpace() will render a ImGuiCol_WindowBg background covering everything excepted the Central Node when empty. Meaning the host window should probably use SetNextWindowBgAlpha(0.0f) prior to Begin() when using this. 2) When Central Node is empty: let inputs pass-through + won't display a DockingEmptyBg background. See demo for details.
+        ImGuiDockNodeFlags_NoSplit                      # Shared/Local // Disable splitting the node into smaller nodes. Useful e.g. when embedding dockspaces into a main root one (the root one may have splitting disabled to reduce confusion). Note: when turned off, existing splits will be preserved.
+        ImGuiDockNodeFlags_NoResize                     # Shared/Local // Disable resizing node using the splitter/separators. Useful with programmatically setup dockspaces.
+        ImGuiDockNodeFlags_AutoHideTabBar               # Shared/Local // Tab bar will automatically hide when there is a single window in the dock node.
 
 
     ctypedef enum ImGuiDragDropFlags_:


### PR DESCRIPTION
Hello.

I've added support for minimal docking space to the docking branch.

* dockspace()
* get_id()
* and some flags

It does not support all related APIs, but it works.

![docking](https://user-images.githubusercontent.com/68057/144645960-56dff48e-2fb4-4489-855b-7a37a45a919d.jpg)

Thank you.
