### PR TITLE
Adding begin/end with support 

### DIFF
--- a/imgui/core.pyx
+++ b/imgui/core.pyx
@@ -3378,6 +3378,11 @@ cdef class _BeginEnd(object):
             self.__class__.__name__, self.expanded, self.opened
         )
 
+    def __eq__(self, other):
+        if other.__class__ is self.__class__:
+            return (self.expanded, self.opened) == (other.expanded, other.opened)
+        return (self.expanded, self.opened) == other
+
 
 def begin(str label, closable=False, cimgui.ImGuiWindowFlags flags=0):
     """Begin a window.
@@ -3462,6 +3467,11 @@ cdef class _BeginEndChild(object):
         return "{}(visible={})".format(
             self.__class__.__name__, self.visible
         )
+
+    def __eq__(self, other):
+        if other.__class__ is self.__class__:
+            return self.visible is other.visible
+        return self.visible is other
 
 
 ctypedef fused child_id:
@@ -4057,37 +4067,37 @@ def set_next_window_size(
 # Useful for non trivial constraints
 cdef _callback_user_info _global_next_window_size_constraints_callback_user_info = _callback_user_info()
 def set_next_window_size_constraints(
-    tuple size_min, 
+    tuple size_min,
     tuple size_max,
     object callback = None,
     user_data = None):
-    """Set next window size limits. use -1,-1 on either X/Y axis to preserve the current size. 
+    """Set next window size limits. use -1,-1 on either X/Y axis to preserve the current size.
     Sizes will be rounded down.
 
     Call before :func:`begin()`.
-    
+
     Args:
         size_min (tuple): Minimum window size, use -1 to conserve current size
         size_max (tuple): Maximum window size, use -1 to conserve current size
-        callback (callable): a callable. 
+        callback (callable): a callable.
             Callable takes an imgui._ImGuiSizeCallbackData object as argument
             Callable should return None
         user_data: Any data that the user want to use in the callback.
-    
+
     .. visual-example::
         :title: Window size constraints
         :height: 200
-        
+
         imgui.set_next_window_size_constraints((175,50), (200, 100))
         imgui.begin("Constrained Window")
         imgui.text("...")
         imgui.end()
-    
+
     .. wraps::
         void SetNextWindowSizeConstraints(
-            const ImVec2& size_min, 
-            const ImVec2& size_max, 
-            ImGuiSizeCallback custom_callback = NULL, 
+            const ImVec2& size_min,
+            const ImVec2& size_max,
+            ImGuiSizeCallback custom_callback = NULL,
             void* custom_callback_user_data = NULL
         )
 
@@ -4098,10 +4108,10 @@ def set_next_window_size_constraints(
         _callback = _ImGuiSizeCallback
         _global_next_window_size_constraints_callback_user_info.populate(callback, user_data)
         _user_data = <void*>_global_next_window_size_constraints_callback_user_info
-        
+
     cimgui.SetNextWindowSizeConstraints(
-        _cast_tuple_ImVec2(size_min), 
-        _cast_tuple_ImVec2(size_max), 
+        _cast_tuple_ImVec2(size_min),
+        _cast_tuple_ImVec2(size_max),
         _callback, _user_data)
 
 def set_next_window_content_size(float width, float height):
@@ -4315,25 +4325,25 @@ def tree_pop():
     cimgui.TreePop()
 
 def get_tree_node_to_label_spacing():
-    """Horizontal distance preceding label when using ``tree_node*()`` 
-    or ``bullet() == (g.FontSize + style.FramePadding.x*2)`` for a 
+    """Horizontal distance preceding label when using ``tree_node*()``
+    or ``bullet() == (g.FontSize + style.FramePadding.x*2)`` for a
     regular unframed TreeNode
-    
+
     Returns:
         float: spacing
-        
+
     .. visual-example::
         :auto_layout:
         :height: 100
         :width: 200
-        
+
         imgui.begin("TreeNode")
         imgui.text("<- 0px offset here")
         if imgui.tree_node("Expand me!", imgui.TREE_NODE_DEFAULT_OPEN):
             imgui.text("<- %.2fpx offset here" % imgui.get_tree_node_to_label_spacing())
             imgui.tree_pop()
         imgui.end()
-    
+
     .. wraps::
         float GetTreeNodeToLabelSpacing()
     """
@@ -4396,12 +4406,12 @@ def collapsing_header(
 
 def set_next_item_open(bool is_open, cimgui.ImGuiCond condition = 0):
     """Set next TreeNode/CollapsingHeader open state.
-    
+
     Args:
         is_open (bool):
         condition (:ref:`condition flag <condition-options>`): defines on which
             condition value should be set. Defaults to :any:`imgui.NONE`.
-    
+
     .. wraps::
         void SetNextItemOpen(bool is_open, ImGuiCond cond = 0)
     """
@@ -4558,6 +4568,11 @@ cdef class _BeginEndListBox(object):
             self.__class__.__name__, self.opened
         )
 
+    def __eq__(self, other):
+        if other.__class__ is self.__class__:
+            return self.opened is other.opened
+        return self.opened is other
+
 
 def begin_list_box(
     str label,
@@ -4565,7 +4580,7 @@ def begin_list_box(
     height = 0
 ):
     """Open a framed scrolling region.
-    
+
     For use if you want to reimplement :func:`listbox()` with custom data
     or interactions. You need to call :func:`end_list_box()` at the end.
 
@@ -4599,7 +4614,7 @@ def begin_list_box(
             const char* label,
             const ImVec2& size = ImVec2(0,0)
         )
-    
+
     """
     return _BeginEndListBox.__new__(
         _BeginEndListBox,
@@ -4608,14 +4623,14 @@ def begin_list_box(
             _cast_args_ImVec2(width, height)
         )
     )
-    
+
 def listbox_header( # OBSOLETED in 1.81 (from February 2021)
     str label,
     width=0,
     height=0
 ):
     """*Obsoleted in imgui v1.81 from February 2021, refer to :func:`begin_list_box()`*
-    
+
     For use if you want to reimplement :func:`listbox()` with custom data
     or interactions. You need to call :func:`listbox_footer()` at the end.
 
@@ -4637,7 +4652,7 @@ def listbox_header( # OBSOLETED in 1.81 (from February 2021)
 
 def end_list_box():
     """
-    
+
     Closing the listbox, previously opened by :func:`begin_list_box()`.
 
     See :func:`begin_list_box()` for usage example.
@@ -4649,7 +4664,7 @@ def end_list_box():
 
 def listbox_footer(): # OBSOLETED in 1.81 (from February 2021)
     """*Obsoleted in imgui v1.81 from February 2021, refer to :func:`end_list_box()`*
-    
+
     Closing the listbox, previously opened by :func:`listbox_header()`.
 
     See :func:`listbox_header()` for usage example.
@@ -4755,6 +4770,11 @@ cdef class _BeginEndMainMenuBar(object):
             self.__class__.__name__, self.opened
         )
 
+    def __eq__(self, other):
+        if other.__class__ is self.__class__:
+            return self.opened is other.opened
+        return self.opened is other
+
 
 def begin_main_menu_bar():
     """Create new full-screen menu bar.
@@ -4828,6 +4848,11 @@ cdef class _BeginEndMenuBar(object):
         return "{}(opened={})".format(
             self.__class__.__name__, self.opened
         )
+
+    def __eq__(self, other):
+        if other.__class__ is self.__class__:
+            return self.opened is other.opened
+        return self.opened is other
 
 
 def begin_menu_bar():
@@ -4904,6 +4929,11 @@ cdef class _BeginEndMenu(object):
         return "{}(opened={})".format(
             self.__class__.__name__, self.opened
         )
+
+    def __eq__(self, other):
+        if other.__class__ is self.__class__:
+            return self.opened is other.opened
+        return self.opened is other
 
 
 def begin_menu(str label, enabled=True):
@@ -5038,13 +5068,13 @@ def open_popup(str label, cimgui.ImGuiPopupFlags flags=0):
     cimgui.OpenPopup(_bytes(label), flags)
 
 def open_popup_on_item_click(str label = None, cimgui.ImGuiPopupFlags popup_flags = 1):
-    """Helper to open popup when clicked on last item. 
+    """Helper to open popup when clicked on last item.
     (note: actually triggers on the mouse _released_ event to be consistent with popup behaviors)
-    
+
     Args:
         label (str): label of the modal window
         flags: ImGuiWindowFlags
-    
+
     .. wraps::
         void OpenPopupOnItemClick(const char* str_id = NULL, ImGuiPopupFlags popup_flags = 1)
     """
@@ -5074,6 +5104,11 @@ cdef class _BeginEndPopup(object):
         return "{}(opened={})".format(
             self.__class__.__name__, self.opened
         )
+
+    def __eq__(self, other):
+        if other.__class__ is self.__class__:
+            return self.opened is other.opened
+        return self.opened is other
 
 
 def begin_popup(str label, cimgui.ImGuiWindowFlags flags=0):
@@ -5149,6 +5184,11 @@ cdef class _BeginEndPopupModal(object):
         return "{}(opened={}, visible={})".format(
             self.__class__.__name__, self.opened, self.visible
         )
+
+    def __eq__(self, other):
+        if other.__class__ is self.__class__:
+            return (self.opened, self.visible) == (other.opened, other.visible)
+        return (self.opened, self.visible) == other
 
 
 def begin_popup_modal(str title, visible=None, cimgui.ImGuiWindowFlags flags=0):
@@ -5312,7 +5352,7 @@ def begin_popup_context_void(str label = None, cimgui.ImGuiPopupFlags popup_flag
 
     Returns:
         opened (bool): if the context window is opened.
-    
+
     .. wraps::
         bool BeginPopupContextVoid(const char* str_id = NULL, ImGuiPopupFlags popup_flags = 1)
     """
@@ -5330,13 +5370,13 @@ def begin_popup_context_void(str label = None, cimgui.ImGuiPopupFlags popup_flag
 
 def is_popup_open( str label,  cimgui.ImGuiPopupFlags flags = 0):
     """Popups: test function
-    
+
     * ``is_popup_open()`` with POPUP_ANY_POPUP_ID: return true if any popup is open at the current BeginPopup() level of the popup stack.
     * ``is_popup_open()`` with POPUP_ANY_POPUP_ID + POPUP_ANY_POPUP_LEVEL: return true if any popup is open.
-    
+
     Returns:
         bool: True if the popup is open at the current ``begin_popup()`` level of the popup stack.
-    
+
     .. wraps::
         bool IsPopupOpen(const char* str_id, ImGuiPopupFlags flags = 0)
     """
@@ -5391,6 +5431,12 @@ cdef class _BeginEndTable(object):
             self.__class__.__name__, self.opened
         )
 
+    def __eq__(self, other):
+        if other.__class__ is self.__class__:
+            return self.opened is other.opened
+        return self.opened is other
+
+
 def begin_table(
     str label,
     int column,
@@ -5400,11 +5446,11 @@ def begin_table(
     float inner_width = 0.0
     ):
     """
-    
+
     .. wraps::
         bool BeginTable(
-            const char* str_id, 
-            int column, 
+            const char* str_id,
+            int column,
             ImGuiTableFlags flags = 0,
             const ImVec2& outer_size = ImVec2(0.0f, 0.0f),
             float inner_width = 0.0f
@@ -5423,7 +5469,7 @@ def begin_table(
 
 def end_table():
     """
-    
+
     .. wraps::
         void EndTable()
     """
@@ -5434,9 +5480,9 @@ def table_next_row(
         float min_row_height = 0.0
     ):
     """
-    
+
     .. wraps::
-        void TableNextRow( 
+        void TableNextRow(
             ImGuiTableRowFlags row_flags = 0,
             float min_row_height = 0.0f
         )
@@ -5445,7 +5491,7 @@ def table_next_row(
 
 def table_next_column():
     """
-    
+
     .. wraps::
         bool TableNextColumn()
     """
@@ -5453,12 +5499,12 @@ def table_next_column():
 
 def table_set_column_index(int column_n):
     """
-    
+
     .. wraps::
         bool TableSetColumnIndex(int column_n)
     """
     return cimgui.TableSetColumnIndex(column_n)
-    
+
 def table_setup_column(
         str label,
         cimgui.ImGuiTableColumnFlags flags = 0,
@@ -5466,10 +5512,10 @@ def table_setup_column(
         cimgui.ImU32 user_id = 0
     ):
     """
-    
+
     .. wraps::
         void TableSetupColumn(
-            const char* label, 
+            const char* label,
             ImGuiTableColumnFlags flags = 0,
             float init_width_or_weight = 0.0f,
             ImU32 user_id  = 0
@@ -5483,7 +5529,7 @@ def table_setup_column(
 
 def table_setup_scroll_freez(int cols, int rows):
     """
-    
+
     .. wraps::
         void TableSetupScrollFreeze(int cols, int rows)
     """
@@ -5491,7 +5537,7 @@ def table_setup_scroll_freez(int cols, int rows):
 
 def table_headers_row():
     """
-    
+
     .. wraps::
         void TableHeadersRow()
     """
@@ -5499,15 +5545,15 @@ def table_headers_row():
 
 def table_header(str label):
     """
-    
+
     .. wraps::
         void TableHeader(const char* label)
     """
     cimgui.TableHeader(_bytes(label))
-    
+
 def table_get_sort_specs():
     """
-    
+
     .. wraps::
         ImGuiTableSortSpecs* TableGetSortSpecs()
     """
@@ -5519,7 +5565,7 @@ def table_get_sort_specs():
 
 def table_get_column_count():
     """
-    
+
     .. wraps::
         int TableGetColumnCount()
     """
@@ -5527,25 +5573,25 @@ def table_get_column_count():
 
 def table_get_column_index():
     """
-    
+
     .. wraps::
         int TableGetColumnIndex()
     """
     return cimgui.TableGetColumnIndex()
-    
+
 def table_get_row_index():
     """
-    
+
     .. wraps::
         int TableGetRowIndex()
     """
     return cimgui.TableGetRowIndex()
-    
+
 def table_get_column_name(int column_n = -1):
     """
-    
+
     .. wraps::
-        const char* TableGetColumnName( 
+        const char* TableGetColumnName(
             int column_n  = -1
         )
     """
@@ -5553,25 +5599,25 @@ def table_get_column_name(int column_n = -1):
 
 def table_get_column_flags(int column_n = -1):
     """
-    
+
     .. wraps::
         ImGuiTableColumnFlags TableGetColumnFlags(
             int column_n = -1
         )
     """
     return cimgui.TableGetColumnFlags(column_n)
-    
+
 def table_set_background_color(
         cimgui.ImGuiTableBgTarget target,
         cimgui.ImU32 color,
         int column_n = -1
     ):
     """
-    
+
     .. wraps::
         void TableSetBgColor(
-            ImGuiTableBgTarget target, 
-            ImU32 color, 
+            ImGuiTableBgTarget target,
+            ImU32 color,
             int column_n  = -1
         )
     """
@@ -5854,7 +5900,7 @@ def arrow_button(str label, cimgui.ImGuiDir direction = DIRECTION_NONE):
 
 def invisible_button(str identifier, float width, float height, cimgui.ImGuiButtonFlags flags = 0):
     """Create invisible button.
-    
+
     Flexible button behavior without the visuals, frequently useful to build custom behaviors using the public api (along with IsItemActive, IsItemHovered, etc.)
 
     .. visual-example::
@@ -6576,7 +6622,7 @@ def drag_float_range2(
     cimgui.ImGuiSliderFlags flags = 0
     ):
     """Display drag float range widget
-    
+
     Args:
         label (str): widget label
         current_min (float): current value of minimum
@@ -6588,11 +6634,11 @@ def drag_float_range2(
         format_max (str): display format for maximum. If None, ``format`` parameter is used.
         flags: SliderFlags flags. See:
             :ref:`list of available flags <slider-flag-options>`.
-            
+
     Returns:
         tuple: a (changed, current_min, current_max) tuple, where ``changed`` indicate
                that the value has been updated.
-    
+
     .. visual-example::
         :auto_layout:
         :width: 400
@@ -6600,36 +6646,36 @@ def drag_float_range2(
 
         vmin = 0
         vmax = 100
-        
+
         imgui.begin("Example: drag float range")
         changed, vmin, vmax = imgui.drag_float_range2( "Drag Range", vmin, vmax )
         imgui.text("Changed: %s, Range: (%.2f, %.2f)" % (changed, vmin, vmax))
         imgui.end()
-   
-    
+
+
     .. wraps::
         bool DragFloatRange2(
-            const char* label, 
-            float* v_current_min, 
-            float* v_current_max, 
-            float v_speed = 1.0f, 
-            float v_min = 0.0f, 
-            float v_max = 0.0f, 
-            const char* format = "%.3f", 
-            const char* format_max = NULL, 
+            const char* label,
+            float* v_current_min,
+            float* v_current_max,
+            float v_speed = 1.0f,
+            float v_min = 0.0f,
+            float v_max = 0.0f,
+            const char* format = "%.3f",
+            const char* format_max = NULL,
             ImGuiSliderFlags flags = 0
         )
     """
-    
+
     cdef float inout_current_min = current_min
     cdef float inout_current_max = current_max
-    
+
     cdef bytes b_format_max;
     cdef char* p_format_max = NULL
     if format_max is not None:
         b_format_max = _bytes(format_max)
         p_format_max = b_format_max
-    
+
     changed = cimgui.DragFloatRange2(
         _bytes(label),
         &inout_current_min,
@@ -6641,10 +6687,10 @@ def drag_float_range2(
         p_format_max,
         flags
     )
-    
+
     return changed, inout_current_min, inout_current_max
-    
-    
+
+
 
 def drag_int(
     str label, int value,
@@ -6890,7 +6936,7 @@ def drag_int_range2(
     cimgui.ImGuiSliderFlags flags = 0
     ):
     """Display drag int range widget
-    
+
     Args:
         label (str): widget label
         current_min (int): current value of minimum
@@ -6902,11 +6948,11 @@ def drag_int_range2(
         format_max (str): display format for maximum. If None, ``format`` parameter is used.
         flags: SliderFlags flags. See:
             :ref:`list of available flags <slider-flag-options>`.
-            
+
     Returns:
         tuple: a (changed, current_min, current_max) tuple, where ``changed`` indicate
                that the value has been updated.
-    
+
     .. visual-example::
         :auto_layout:
         :width: 400
@@ -6914,36 +6960,36 @@ def drag_int_range2(
 
         vmin = 0
         vmax = 100
-        
+
         imgui.begin("Example: drag float range")
         changed, vmin, vmax = imgui.drag_int_range2( "Drag Range", vmin, vmax )
         imgui.text("Changed: %s, Range: (%d, %d)" % (changed, vmin, vmax))
         imgui.end()
-   
-    
+
+
     .. wraps::
         bool DragIntRange2(
-            const char* label, 
-            int* v_current_min, 
-            int* v_current_max, 
-            float v_speed = 1.0f, 
-            int v_min = 0, 
-            int v_max = 0, 
-            const char* format = "%d", 
-            const char* format_max = NULL, 
+            const char* label,
+            int* v_current_min,
+            int* v_current_max,
+            float v_speed = 1.0f,
+            int v_min = 0,
+            int v_max = 0,
+            const char* format = "%d",
+            const char* format_max = NULL,
             ImGuiSliderFlags flags = 0
         )
     """
-    
+
     cdef int inout_current_min = current_min
     cdef int inout_current_max = current_max
-    
+
     cdef bytes b_format_max;
     cdef char* p_format_max = NULL
     if format_max is not None:
         b_format_max = _bytes(format_max)
         p_format_max = b_format_max
-    
+
     changed = cimgui.DragIntRange2(
         _bytes(label),
         &inout_current_min,
@@ -6955,7 +7001,7 @@ def drag_int_range2(
         p_format_max,
         flags
     )
-    
+
     return changed, inout_current_min, inout_current_max
 
 
@@ -6970,9 +7016,9 @@ def drag_scalar(
     cimgui.ImGuiSliderFlags flags = 0):
     """Display scalar drag widget.
     Data is passed via ``bytes`` and the type is separatelly given using ``data_type``.
-    This is useful to work with specific types (e.g. unsigned 8bit integer, float, double) 
-    like when interfacing with Numpy. 
-    
+    This is useful to work with specific types (e.g. unsigned 8bit integer, float, double)
+    like when interfacing with Numpy.
+
     Args:
         label (str): widget label
         data_type: ImGuiDataType enum, type of the given data
@@ -6984,29 +7030,29 @@ def drag_scalar(
             format string. **Warning:** highly unsafe. See :any:`drag_int()`.
         flags: ImGuiSlider flags. See:
             :ref:`list of available flags <slider-flag-options>`.
-    
+
     Returns:
         tuple: a ``(changed, value)`` tuple that contains indicator of
         drag state change and the current drag content.
-    
+
     .. wraps::
         bool DragScalar(
-            const char* label, 
-            ImGuiDataType data_type, 
-            void* p_data, 
-            float v_speed, 
+            const char* label,
+            ImGuiDataType data_type,
+            void* p_data,
+            float v_speed,
             const void* p_min = NULL,
             const void* p_max = NULL,
             const char* format = NULL,
             ImGuiSliderFlags flags = 0
         )
     """
-    
+
     cdef char* p_data = data
     cdef char* p_min = NULL
     if min_value is not None:
         p_min = min_value
-    cdef char* p_max = NULL 
+    cdef char* p_max = NULL
     if max_value is not None:
         p_max = max_value
     cdef char* fmt = NULL
@@ -7014,7 +7060,7 @@ def drag_scalar(
     if format is not None:
         fmt_data = _bytes(format)
         fmt = fmt_data
-        
+
     cdef changed = cimgui.DragScalar(
         _bytes(label),
         data_type,
@@ -7025,7 +7071,7 @@ def drag_scalar(
         fmt,
         flags
     )
-    
+
     return changed, data
 
 def drag_scalar_N(
@@ -7040,9 +7086,9 @@ def drag_scalar_N(
     cimgui.ImGuiSliderFlags flags = 0):
     """Display multiple scalar drag widget.
     Data is passed via ``bytes`` and the type is separatelly given using ``data_type``.
-    This is useful to work with specific types (e.g. unsigned 8bit integer, float, double) 
-    like when interfacing with Numpy. 
-    
+    This is useful to work with specific types (e.g. unsigned 8bit integer, float, double)
+    like when interfacing with Numpy.
+
     Args:
         label (str): widget label
         data_type: ImGuiDataType enum, type of the given data
@@ -7055,30 +7101,30 @@ def drag_scalar_N(
             format string. **Warning:** highly unsafe. See :any:`drag_int()`.
         flags: ImGuiSlider flags. See:
             :ref:`list of available flags <slider-flag-options>`.
-    
+
     Returns:
         tuple: a ``(changed, value)`` tuple that contains indicator of
         drag state change and the current drag content.
-    
+
     .. wraps::
         bool DragScalarN(
-            const char* label, 
-            ImGuiDataType data_type, 
+            const char* label,
+            ImGuiDataType data_type,
             void* p_data,
             int components,
-            float v_speed, 
+            float v_speed,
             const void* p_min = NULL,
             const void* p_max = NULL,
             const char* format = NULL,
             ImGuiSliderFlags flags = 0
         )
     """
-    
+
     cdef char* p_data = data
     cdef char* p_min = NULL
     if min_value is not None:
         p_min = min_value
-    cdef char* p_max = NULL 
+    cdef char* p_max = NULL
     if max_value is not None:
         p_max = max_value
     cdef char* fmt = NULL
@@ -7086,7 +7132,7 @@ def drag_scalar_N(
     if format is not None:
         fmt_data = _bytes(format)
         fmt = fmt_data
-        
+
     cdef changed = cimgui.DragScalarN(
         _bytes(label),
         data_type,
@@ -7098,7 +7144,7 @@ def drag_scalar_N(
         fmt,
         flags
     )
-    
+
     return changed, data
 
 def input_text(
@@ -7136,7 +7182,7 @@ def input_text(
         buffer_length (int): length of the content buffer
         flags: InputText flags. See:
             :ref:`list of available flags <inputtext-flag-options>`.
-        callback (callable): a callable that is called depending on choosen flags. 
+        callback (callable): a callable that is called depending on choosen flags.
             Callable takes an imgui._ImGuiInputTextCallbackData object as argument
             Callable should return None or integer
         user_data: Any data that the user want to use in the callback.
@@ -7155,7 +7201,7 @@ def input_text(
             void* user_data = NULL
         )
     """
-    
+
     cdef _callback_user_info _user_info = _callback_user_info()
     cdef cimgui.ImGuiInputTextCallback _callback = NULL
     cdef void *_user_data = NULL
@@ -7163,7 +7209,7 @@ def input_text(
         _callback = _ImGuiInputTextCallback
         _user_info.populate(callback, user_data)
         _user_data = <void*>_user_info
-    
+
     # todo: pymalloc
     cdef char* inout_text = <char*>malloc(buffer_length * sizeof(char))
     # todo: take special care of terminating char
@@ -7217,7 +7263,7 @@ def input_text_multiline(
         height (float): height of the textbox
         flags: InputText flags. See:
             :ref:`list of available flags <inputtext-flag-options>`.
-        callback (callable): a callable that is called depending on choosen flags. 
+        callback (callable): a callable that is called depending on choosen flags.
             Callable takes an imgui._ImGuiInputTextCallbackData object as argument
             Callable should return None or integer
         user_data: Any data that the user want to use in the callback.
@@ -7237,7 +7283,7 @@ def input_text_multiline(
             void* user_data = NULL
         )
     """
-    
+
     cdef _callback_user_info _user_info = _callback_user_info()
     cdef cimgui.ImGuiInputTextCallback _callback = NULL
     cdef void *_user_data = NULL
@@ -7245,7 +7291,7 @@ def input_text_multiline(
         _callback = _ImGuiInputTextCallback
         _user_info.populate(callback, user_data)
         _user_data = <void*>_user_info
-        
+
     cdef char* inout_text = <char*>malloc(buffer_length * sizeof(char))
     # todo: take special care of terminating char
     strncpy(inout_text, _bytes(value), buffer_length)
@@ -7259,10 +7305,10 @@ def input_text_multiline(
 
     free(inout_text)
     return changed, output
-    
+
 def input_text_with_hint(
-    str label, 
-    str hint, 
+    str label,
+    str hint,
     str value,
     int buffer_length,
     cimgui.ImGuiInputTextFlags flags = 0,
@@ -7270,7 +7316,7 @@ def input_text_with_hint(
     user_data = None):
     """Display a text box, if the text is empty a hint on how to fill the box is given.
     ``buffer_length`` is the maximum allowed length of the content.
-    
+
     Args:
         label (str): Widget label
         hing (str): Hint displayed if text value empty
@@ -7278,39 +7324,39 @@ def input_text_with_hint(
         buffer_length (int): Length of the content buffer
         flags: InputText flags. See:
             :ref:`list of available flags <inputtext-flag-options>`.
-        callback (callable): a callable that is called depending on choosen flags. 
+        callback (callable): a callable that is called depending on choosen flags.
             Callable takes an imgui._ImGuiInputTextCallbackData object as argument
             Callable should return None or integer
         user_data: Any data that the user want to use in the callback.
-            
+
     Returns:
         tuple: a ``(changed, value)`` tuple that contains indicator of
         textbox state change and the current text contents.
-    
+
     .. visual-example::
         :auto_layout:
         :width: 400
         :height: 200
-        
+
         text_val = ''
         imgui.begin("Example Text With hing")
         changed, text_val = imgui.input_text_with_hint(
-            'Email', 'your@email.com', 
+            'Email', 'your@email.com',
             text_val, 255)
         imgui.end()
-    
+
     .. wraps::
         bool InputTextWithHint(
-            const char* label, 
-            const char* hint, 
-            char* buf, 
-            size_t buf_size, 
-            ImGuiInputTextFlags flags = 0, 
-            ImGuiInputTextCallback callback = NULL, 
+            const char* label,
+            const char* hint,
+            char* buf,
+            size_t buf_size,
+            ImGuiInputTextFlags flags = 0,
+            ImGuiInputTextCallback callback = NULL,
             void* user_data = NULL
         )
     """
-    
+
     cdef _callback_user_info _user_info = _callback_user_info()
     cdef cimgui.ImGuiInputTextCallback _callback = NULL
     cdef void *_user_data = NULL
@@ -7318,17 +7364,17 @@ def input_text_with_hint(
         _callback = _ImGuiInputTextCallback
         _user_info.populate(callback, user_data)
         _user_data = <void*>_user_info
-        
+
     cdef char* inout_text = <char*>malloc(buffer_length * sizeof(char))
     strncpy(inout_text, _bytes(value), buffer_length)
-    
+
     changed = cimgui.InputTextWithHint(
         _bytes(label), _bytes(hint), inout_text, buffer_length,
         flags, _callback, _user_data
     )
-    
+
     output = _from_bytes(inout_text)
-    
+
     free(inout_text)
     return changed, output
 
@@ -7754,9 +7800,9 @@ def input_scalar(
     cimgui.ImGuiInputTextFlags flags = 0):
     """Display scalar input widget.
     Data is passed via ``bytes`` and the type is separatelly given using ``data_type``.
-    This is useful to work with specific types (e.g. unsigned 8bit integer, float, double) 
-    like when interfacing with Numpy. 
-    
+    This is useful to work with specific types (e.g. unsigned 8bit integer, float, double)
+    like when interfacing with Numpy.
+
     Args:
         label (str): widget label
         data_type: ImGuiDataType enum, type of the given data
@@ -7766,28 +7812,28 @@ def input_scalar(
         format (str): format string
         flags: InputText flags. See:
             :ref:`list of available flags <inputtext-flag-options>`.
-    
+
     Returns:
         tuple: a ``(changed, value)`` tuple that contains indicator of
         input state change and the current input content.
-    
+
     .. wraps::
         bool InputScalar(
-            const char* label, 
-            ImGuiDataType data_type, 
-            void* p_data, 
-            const void* p_step = NULL, 
-            const void* p_step_fast = NULL, 
-            const char* format = NULL, 
+            const char* label,
+            ImGuiDataType data_type,
+            void* p_data,
+            const void* p_step = NULL,
+            const void* p_step_fast = NULL,
+            const char* format = NULL,
             ImGuiInputTextFlags flags = 0
         )
     """
-    
+
     cdef char* p_data = data
     cdef char* p_step = NULL
     if step is not None:
         p_step = step
-    cdef char* p_step_fast = NULL 
+    cdef char* p_step_fast = NULL
     if step_fast is not None:
         p_step_fast = step_fast
     cdef char* fmt = NULL
@@ -7795,7 +7841,7 @@ def input_scalar(
     if format is not None:
         fmt_data = _bytes(format)
         fmt = fmt_data
-        
+
     cdef changed = cimgui.InputScalar(
         _bytes(label),
         data_type,
@@ -7805,7 +7851,7 @@ def input_scalar(
         fmt,
         flags
     )
-    
+
     return changed, data
 
 def input_scalar_N(
@@ -7819,9 +7865,9 @@ def input_scalar_N(
     cimgui.ImGuiInputTextFlags flags = 0):
     """Display multiple scalar input widget.
     Data is passed via ``bytes`` and the type is separatelly given using ``data_type``.
-    This is useful to work with specific types (e.g. unsigned 8bit integer, float, double) 
-    like when interfacing with Numpy. 
-    
+    This is useful to work with specific types (e.g. unsigned 8bit integer, float, double)
+    like when interfacing with Numpy.
+
     Args:
         label (str): widget label
         data_type: ImGuiDataType enum, type of the given data
@@ -7832,29 +7878,29 @@ def input_scalar_N(
         format (str): format string
         flags: InputText flags. See:
             :ref:`list of available flags <inputtext-flag-options>`.
-    
+
     Returns:
         tuple: a ``(changed, value)`` tuple that contains indicator of
         input state change and the current input content.
-    
+
     .. wraps::
         bool InputScalarN(
-            const char* label, 
-            ImGuiDataType data_type, 
+            const char* label,
+            ImGuiDataType data_type,
             void* p_data,
             int components,
-            const void* p_step = NULL, 
-            const void* p_step_fast = NULL, 
-            const char* format = NULL, 
+            const void* p_step = NULL,
+            const void* p_step_fast = NULL,
+            const char* format = NULL,
             ImGuiInputTextFlags flags = 0
         )
     """
-    
+
     cdef char* p_data = data
     cdef char* p_step = NULL
     if step is not None:
         p_step = step
-    cdef char* p_step_fast = NULL 
+    cdef char* p_step_fast = NULL
     if step_fast is not None:
         p_step_fast = step_fast
     cdef char* fmt = NULL
@@ -7862,7 +7908,7 @@ def input_scalar_N(
     if format is not None:
         fmt_data = _bytes(format)
         fmt = fmt_data
-        
+
     cdef changed = cimgui.InputScalarN(
         _bytes(label),
         data_type,
@@ -7873,15 +7919,15 @@ def input_scalar_N(
         fmt,
         flags
     )
-    
+
     return changed, data
-    
+
 def slider_float(
     str label,
     float value,
     float min_value,
     float max_value,
-    str format = "%.3f", 
+    str format = "%.3f",
     cimgui.ImGuiSliderFlags flags = 0,
     float power=1.0 # OBSOLETED in 1.78 (from June 2020)
 ):
@@ -8123,28 +8169,28 @@ def slider_float4(
     ), (inout_values[0], inout_values[1], inout_values[2], inout_values[3])
 
 def slider_angle(
-    str label, 
+    str label,
     float rad_value,
-    float value_degrees_min = -360.0, 
+    float value_degrees_min = -360.0,
     float value_degrees_max = 360,
-    str format = "%.0f deg", 
+    str format = "%.0f deg",
     cimgui.ImGuiSliderFlags flags = 0):
     """Display angle slider widget.
-    
+
     .. visual-example::
         :auto_layout:
         :width: 400
         :height: 130
-        
+
         radian = 3.1415/4
-        
+
         imgui.begin("Example: slider angle")
         changed, radian = imgui.slider_angle(
             "slider angle", radian,
             value_degrees_min=0.0, value_degrees_max=180.0)
         imgui.text("Changed: %s, Value: %s" % (changed, radian))
         imgui.end()
-    
+
     Args:
         labal (str): widget label
         rad_value (float): slider value in radian
@@ -8154,22 +8200,22 @@ def slider_angle(
             format string. **Warning:** highly unsafe.
         flags: SliderFlags flags. See:
             :ref:`list of available flags <slider-flag-options>`.
-        
+
     Returns:
         tuple: a ``(changed, rad_value)`` tuple that contains indicator of
         widget state change and the current slider value in radian.
-        
-    
+
+
     .. wraps::
         bool SliderAngle(
-            const char* label, 
-            float* v_rad, float 
-            v_degrees_min = -360.0f, 
-            float v_degrees_max = +360.0f, 
-            const char* format = "%.0f deg", 
+            const char* label,
+            float* v_rad, float
+            v_degrees_min = -360.0f,
+            float v_degrees_max = +360.0f,
+            const char* format = "%.0f deg",
             ImGuiSliderFlags flags = 0
         )
-    
+
     """
     cdef float inout_r_value = rad_value
     return cimgui.SliderAngle(
@@ -8418,9 +8464,9 @@ def slider_scalar(
     cimgui.ImGuiSliderFlags flags = 0):
     """Display scalar slider widget.
     Data is passed via ``bytes`` and the type is separatelly given using ``data_type``.
-    This is useful to work with specific types (e.g. unsigned 8bit integer, float, double) 
-    like when interfacing with Numpy. 
-    
+    This is useful to work with specific types (e.g. unsigned 8bit integer, float, double)
+    like when interfacing with Numpy.
+
     Args:
         label (str): widget label
         data_type: ImGuiDataType enum, type of the given data
@@ -8431,15 +8477,15 @@ def slider_scalar(
             format string. **Warning:** highly unsafe. See :any:`drag_int()`.
         flags: ImGuiSlider flags. See:
             :ref:`list of available flags <slider-flag-options>`.
-    
+
     Returns:
         tuple: a ``(changed, value)`` tuple that contains indicator of
         slider state change and the current slider content.
-    
+
     .. wraps::
         bool SliderScalar(
-            const char* label, 
-            ImGuiDataType data_type, 
+            const char* label,
+            ImGuiDataType data_type,
             void* p_data,
             const void* p_min,
             const void* p_max,
@@ -8447,17 +8493,17 @@ def slider_scalar(
             ImGuiSliderFlags flags = 0
         )
     """
-    
+
     cdef char* p_data = data
     cdef char* p_min = min_value
-    cdef char* p_max = max_value 
-    
+    cdef char* p_max = max_value
+
     cdef char* fmt = NULL
     cdef bytes fmt_data;
     if format is not None:
         fmt_data = _bytes(format)
         fmt = fmt_data
-        
+
     cdef changed = cimgui.SliderScalar(
         _bytes(label),
         data_type,
@@ -8467,9 +8513,9 @@ def slider_scalar(
         fmt,
         flags
     )
-    
+
     return changed, data
-    
+
 def slider_scalar_N(
     str label,
     cimgui.ImGuiDataType data_type,
@@ -8481,9 +8527,9 @@ def slider_scalar_N(
     cimgui.ImGuiSliderFlags flags = 0):
     """Display multiple scalar slider widget.
     Data is passed via ``bytes`` and the type is separatelly given using ``data_type``.
-    This is useful to work with specific types (e.g. unsigned 8bit integer, float, double) 
-    like when interfacing with Numpy. 
-    
+    This is useful to work with specific types (e.g. unsigned 8bit integer, float, double)
+    like when interfacing with Numpy.
+
     Args:
         label (str): widget label
         data_type: ImGuiDataType enum, type of the given data
@@ -8495,16 +8541,16 @@ def slider_scalar_N(
             format string. **Warning:** highly unsafe. See :any:`drag_int()`.
         flags: ImGuiSlider flags. See:
             :ref:`list of available flags <slider-flag-options>`.
-    
+
     Returns:
         tuple: a ``(changed, value)`` tuple that contains indicator of
         slider state change and the current slider content.
-    
+
     .. wraps::
         bool SliderScalarN(
-            const char* label, 
-            ImGuiDataType data_type, 
-            void* p_data, 
+            const char* label,
+            ImGuiDataType data_type,
+            void* p_data,
             int components,
             const void* p_min,
             const void* p_max,
@@ -8512,17 +8558,17 @@ def slider_scalar_N(
             ImGuiSliderFlags flags = 0
         )
     """
-    
+
     cdef char* p_data = data
     cdef char* p_min = min_value
-    cdef char* p_max = max_value 
-    
+    cdef char* p_max = max_value
+
     cdef char* fmt = NULL
     cdef bytes fmt_data;
     if format is not None:
         fmt_data = _bytes(format)
         fmt = fmt_data
-        
+
     cdef changed = cimgui.SliderScalarN(
         _bytes(label),
         data_type,
@@ -8533,7 +8579,7 @@ def slider_scalar_N(
         fmt,
         flags
     )
-    
+
     return changed, data
 
 def v_slider_float(
@@ -8666,7 +8712,7 @@ def v_slider_int(
         min_value, max_value, _bytes(format), flags
     ), inout_value
 
-    
+
 def v_slider_scalar(
     str label,
     float width,
@@ -8679,9 +8725,9 @@ def v_slider_scalar(
     cimgui.ImGuiSliderFlags flags = 0):
     """Display vertical scalar slider widget.
     Data is passed via ``bytes`` and the type is separatelly given using ``data_type``.
-    This is useful to work with specific types (e.g. unsigned 8bit integer, float, double) 
-    like when interfacing with Numpy. 
-    
+    This is useful to work with specific types (e.g. unsigned 8bit integer, float, double)
+    like when interfacing with Numpy.
+
     Args:
         label (str): widget label
         width (float): width of the slider
@@ -8694,34 +8740,34 @@ def v_slider_scalar(
             format string. **Warning:** highly unsafe. See :any:`drag_int()`.
         flags: ImGuiSlider flags. See:
             :ref:`list of available flags <slider-flag-options>`.
-    
+
     Returns:
         tuple: a ``(changed, value)`` tuple that contains indicator of
         slider state change and the current slider content.
-    
+
     .. wraps::
         bool VSliderScalar(
-            const char* label, 
+            const char* label,
             const ImVec2& size,
-            ImGuiDataType data_type, 
-            void* p_data, 
+            ImGuiDataType data_type,
+            void* p_data,
             const void* p_min,
             const void* p_max,
             const char* format = NULL,
             ImGuiSliderFlags flags = 0
         )
     """
-    
+
     cdef char* p_data = data
     cdef char* p_min = min_value
     cdef char* p_max = max_value
-    
+
     cdef char* fmt = NULL
     cdef bytes fmt_data;
     if format is not None:
         fmt_data = _bytes(format)
         fmt = fmt_data
-        
+
     cdef changed = cimgui.VSliderScalar(
         _bytes(label),
         _cast_args_ImVec2(width, height),
@@ -8732,7 +8778,7 @@ def v_slider_scalar(
         fmt,
         flags
     )
-    
+
     return changed, data
 
 def plot_lines(
@@ -8941,7 +8987,7 @@ def progress_bar(float fraction, size = (-FLOAT_MIN,0), str overlay = ""):
     .. wraps::
         void ProgressBar(
             float fraction,
-            const ImVec2& size_arg = ImVec2(-FLT_MIN, 0), 
+            const ImVec2& size_arg = ImVec2(-FLT_MIN, 0),
             const char* overlay = NULL
         )
 
@@ -9008,9 +9054,9 @@ def is_item_active():
 
 
 def is_item_clicked(cimgui.ImGuiMouseButton mouse_button = 0):
-    """ Was the last item hovered and mouse clicked on? 
+    """ Was the last item hovered and mouse clicked on?
     Button or node that was just being clicked on.
-    
+
     Args:
         mouse_button: ImGuiMouseButton
 
@@ -9036,12 +9082,12 @@ def is_item_visible():
     return cimgui.IsItemVisible()
 
 def is_item_edited():
-    """Did the last item modify its underlying value this frame? or was pressed? 
+    """Did the last item modify its underlying value this frame? or was pressed?
     This is generally the same as the "bool" return value of many widgets.
-    
+
     Returns:
         bool: True if item is edited, otherwise False.
-    
+
     .. wraps::
         bool IsItemEdited()
     """
@@ -9049,35 +9095,35 @@ def is_item_edited():
 
 def is_item_activated():
     """Was the last item just made active (item was previously inactive)?
-    
+
     Returns:
         bool: True if item was just made active
-    
+
     .. wraps::
         bool IsItemActivated()
     """
     return cimgui.IsItemActivated()
 
 def is_item_deactivated():
-    """Was the last item just made inactive (item was previously active)? 
+    """Was the last item just made inactive (item was previously active)?
     Useful for Undo/Redo patterns with widgets that requires continuous editing.
-        
+
     Results:
         bool: True if item just made inactive
-        
+
     .. wraps:
         bool IsItemDeactivated()
     """
     return cimgui.IsItemDeactivated
 
 def is_item_deactivated_after_edit():
-    """Was the last item just made inactive and made a value change when it was active? (e.g. Slider/Drag moved). 
-    Useful for Undo/Redo patterns with widgets that requires continuous editing. 
+    """Was the last item just made inactive and made a value change when it was active? (e.g. Slider/Drag moved).
+    Useful for Undo/Redo patterns with widgets that requires continuous editing.
     Note that you may get false positives (some widgets such as Combo()/ListBox()/Selectable() will return true even when clicking an already selected item).
-    
+
     Results:
         bool: True if item just made inactive after an edition
-    
+
     .. wraps::
         bool IsItemDeactivatedAfterEdit()
     """
@@ -9085,7 +9131,7 @@ def is_item_deactivated_after_edit():
 
 def is_item_toggled_open():
     """Was the last item open state toggled? set by TreeNode().
-    
+
     .. wraps::
         bool IsItemToggledOpen()
     """
@@ -9174,15 +9220,15 @@ def set_item_allow_overlap():
     cimgui.SetItemAllowOverlap()
 
 def get_main_viewport():
-    """Currently represents the Platform Window created by the application which is hosting 
+    """Currently represents the Platform Window created by the application which is hosting
     our Dear ImGui windows.
-    
-    In the future we will extend this concept further to also represent Platform Monitor 
+
+    In the future we will extend this concept further to also represent Platform Monitor
     and support a "no main platform window" operation mode.
-    
+
     Returns:
         _ImGuiViewport: Viewport
-    
+
     .. wraps::
         ImGuiViewport* GetMainViewport()
     """
@@ -9256,26 +9302,26 @@ def get_time():
     """
     return cimgui.GetTime()
 
-    
+
 def get_background_draw_list():
-    """This draw list will be the first rendering one. 
+    """This draw list will be the first rendering one.
     Useful to quickly draw shapes/text behind dear imgui contents.
-    
+
     Returns:
         DrawList*
-        
+
     .. wraps::
         ImDrawList* GetBackgroundDrawList()
     """
     return _DrawList.from_ptr(cimgui.GetBackgroundDrawList())
-    
+
 def get_foreground_draw_list():
-    """This draw list will be the last rendered one. 
+    """This draw list will be the last rendered one.
     Useful to quickly draw shapes/text over dear imgui contents.
-    
+
     Returns:
         DrawList*
-        
+
     .. wraps::
         ImDrawList* GetForegroundDrawList()
     """
@@ -9498,73 +9544,73 @@ def set_mouse_cursor(cimgui.ImGuiMouseCursor mouse_cursor_type):
     return cimgui.SetMouseCursor(mouse_cursor_type)
 
 def capture_mouse_from_app(bool want_capture_mouse_value = True):
-    """Attention: misleading name! 
-    Manually override io.WantCaptureMouse flag next frame 
-    (said flag is entirely left for your application to handle). 
-    
-    This is equivalent to setting "io.WantCaptureMouse = want_capture_mouse_value;" 
+    """Attention: misleading name!
+    Manually override io.WantCaptureMouse flag next frame
+    (said flag is entirely left for your application to handle).
+
+    This is equivalent to setting "io.WantCaptureMouse = want_capture_mouse_value;"
     after the next NewFrame() call.
-    
+
     .. wraps::
         void CaptureMouseFromApp(bool want_capture_mouse_value = true)
     """
     cimgui.CaptureMouseFromApp(want_capture_mouse_value)
-    
+
 def get_clipboard_text():
-    """Also see the ``log_to_clipboard()`` function to capture GUI into clipboard, 
+    """Also see the ``log_to_clipboard()`` function to capture GUI into clipboard,
     or easily output text data to the clipboard.
-    
+
     Returns:
         str: Text content of the clipboard
-    
+
     .. wraps::
         const char* GetClipboardText()
     """
     return _from_bytes(cimgui.GetClipboardText())
-    
+
 def load_ini_settings_from_disk(str ini_file_name):
-    """Call after ``create_context()`` and before the first call to ``new_frame()``. 
+    """Call after ``create_context()`` and before the first call to ``new_frame()``.
     ``new_frame()`` automatically calls ``load_ini_settings_from_disk(io.ini_file_name)``.
-    
+
     Args:
         ini_file_name (str): Filename to load settings from.
-    
+
     .. wraps::
         void LoadIniSettingsFromDisk(const char* ini_filename)
     """
     cimgui.LoadIniSettingsFromDisk(_bytes(ini_file_name))
 
 def load_ini_settings_from_memory(str ini_data):
-    """Call after ``create_context()`` and before the first call to ``new_frame()`` 
+    """Call after ``create_context()`` and before the first call to ``new_frame()``
     to provide .ini data from your own data source.
-    
+
     .. wraps::
         void LoadIniSettingsFromMemory(const char* ini_data, size_t ini_size=0)
     """
     #cdef size_t ini_size = len(ini_data)
     cimgui.LoadIniSettingsFromMemory(_bytes(ini_data), 0)
-    
+
 def save_ini_settings_to_disk(str ini_file_name):
-    """This is automatically called (if ``io.ini_file_name`` is not empty) 
-    a few seconds after any modification that should be reflected in the .ini file 
+    """This is automatically called (if ``io.ini_file_name`` is not empty)
+    a few seconds after any modification that should be reflected in the .ini file
     (and also by ``destroy_context``).
-    
+
     Args:
         ini_file_name (str): Filename to save settings to.
-    
+
     .. wraps::
         void SaveIniSettingsToDisk(const char* ini_filename)
     """
     cimgui.SaveIniSettingsToDisk(_bytes(ini_file_name))
-    
+
 def save_ini_settings_to_memory():
-    """Return a string with the .ini data which you can save by your own mean. 
-    Call when ``io.want_save_ini_settings`` is set, then save data by your own mean 
-    and clear ``io.want_save_ini_settings``. 
-    
+    """Return a string with the .ini data which you can save by your own mean.
+    Call when ``io.want_save_ini_settings`` is set, then save data by your own mean
+    and clear ``io.want_save_ini_settings``.
+
     Returns:
         str: Settings data
-    
+
     .. wraps::
        const char* SaveIniSettingsToMemory(size_t* out_ini_size = NULL)
     """
@@ -9572,10 +9618,10 @@ def save_ini_settings_to_memory():
 
 def set_clipboard_text(str text):
     """Set the clipboard content
-    
+
     Args:
         text (str): Text to copy in clipboard
-    
+
     .. wraps:
         void SetClipboardText(const char* text)
     """
@@ -9595,16 +9641,16 @@ def set_clipboard_text(str text):
 #        void SetScrollHere(float center_y_ratio = 0.5f)
 #    """
 #    return cimgui.SetScrollHere(center_y_ratio)
-    
+
 def set_scroll_here_x(float center_x_ratio = 0.5):
     """Set scroll here X.
 
-    Adjust scrolling amount to make current cursor position visible. 
+    Adjust scrolling amount to make current cursor position visible.
     center_x_ratio =
-        0.0: left, 
-        0.5: center, 
-        1.0: right. 
-        
+        0.0: left,
+        0.5: center,
+        1.0: right.
+
     When using to make a "default/current item" visible, consider using SetItemDefaultFocus() instead.
 
     Args:
@@ -9614,16 +9660,16 @@ def set_scroll_here_x(float center_x_ratio = 0.5):
         void SetScrollHereX(float center_x_ratio = 0.5f)
     """
     return cimgui.SetScrollHereX(center_x_ratio)
-    
+
 def set_scroll_here_y(float center_y_ratio = 0.5):
     """Set scroll here Y.
 
-    Adjust scrolling amount to make current cursor position visible. 
+    Adjust scrolling amount to make current cursor position visible.
     center_y_ratio =
-        0.0: top, 
-        0.5: center, 
-        1.0: bottom. 
-        
+        0.0: top,
+        0.5: center,
+        1.0: bottom.
+
     When using to make a "default/current item" visible, consider using SetItemDefaultFocus() instead.
 
     Args:
@@ -9638,9 +9684,9 @@ def set_scroll_here_y(float center_y_ratio = 0.5):
 def set_scroll_from_pos_x(float local_x, float center_x_ratio = 0.5):
     """Set scroll from position X
 
-    Adjust scrolling amount to make given position visible. 
+    Adjust scrolling amount to make given position visible.
     Generally GetCursorStartPos() + offset to compute a valid position.
-    
+
     Args:
         float local_x
         float center_x_ratio = 0.5f
@@ -9654,9 +9700,9 @@ def set_scroll_from_pos_x(float local_x, float center_x_ratio = 0.5):
 def set_scroll_from_pos_y(float local_y, float center_y_ratio = 0.5):
     """Set scroll from position Y
 
-    Adjust scrolling amount to make given position visible. 
+    Adjust scrolling amount to make given position visible.
     Generally GetCursorStartPos() + offset to compute a valid position.
-    
+
     Args:
         float local_y
         float center_y_ratio = 0.5f
@@ -9755,16 +9801,16 @@ cpdef calc_text_size(str text, bool hide_text_after_double_hash = False, float w
             wrap_width
         )
     )
-    
+
 def color_convert_u32_to_float4(cimgui.ImU32 in_):
     """Convert an unsigned int 32 to 4 component r, g, b, a
-    
+
     Args:
         in_ (ImU32): Color in unsigned int 32 format
-    
+
     Return:
         tuple: r, g, b, a components of the color
-    
+
     .. wraps::
         ImVec4 ColorConvertU32ToFloat4(ImU32 in)
     """
@@ -9772,13 +9818,13 @@ def color_convert_u32_to_float4(cimgui.ImU32 in_):
 
 def color_convert_float4_to_u32(float r, float g, float b, float a):
     """Convert a set of r, g, b, a floats to unsigned int 32 color
-    
+
     Args:
         r, g, b, a (float): Components of the color
-    
+
     Returns:
         ImU32: Unsigned int 32 color format
-    
+
     .. wraps::
         ImU32 ColorConvertFloat4ToU32(const ImVec4& in)
     """
@@ -9787,13 +9833,13 @@ def color_convert_float4_to_u32(float r, float g, float b, float a):
 
 def color_convert_rgb_to_hsv(float r, float g, float b):
     """Convert color from RGB space to HSV space
-    
+
     Args:
         r, g, b (float): RGB color format
-    
+
     Returns:
         tuple: h, s, v HSV color format
-    
+
     .. wraps::
         void ColorConvertRGBtoHSV(float r, float g, float b, float& out_h, float& out_s, float& out_v)
     """
@@ -9801,16 +9847,16 @@ def color_convert_rgb_to_hsv(float r, float g, float b):
     out_h = out_s = out_v = 0
     cimgui.ColorConvertRGBtoHSV(r,g,b,out_h,out_s,out_v)
     return out_h, out_s, out_v
-    
+
 def color_convert_hsv_to_rgb(float h, float s, float v):
     """Convert color from HSV space to RGB space
-    
+
     Args:
         h, s, v (float): HSV color format
-    
+
     Returns:
         tuple: r, g, b RGB color format
-    
+
     .. wraps::
         void ColorConvertHSVtoRGB(float h, float s, float v, float& out_r, float& out_g, float& out_b)
     """
@@ -10329,7 +10375,7 @@ def unindent(float width=0.0):
 def columns(int count=1, str identifier=None, bool border=True):
     """Setup number of columns. Use an identifier to distinguish multiple
     column sets. close with ``columns(1)``.
-    
+
     Legacy Columns API (2020: prefer using Tables!)
 
     .. visual-example::
@@ -10392,7 +10438,7 @@ def next_column():
     """Move to the next column drawing.
 
     For a complete example see :func:`columns()`.
-    
+
     Legacy Columns API (2020: prefer using Tables!)
 
     .. wraps::
@@ -10405,7 +10451,7 @@ def get_column_index():
     """Returns the current column index.
 
     For a complete example see :func:`columns()`.
-    
+
     Legacy Columns API (2020: prefer using Tables!)
 
     Returns:
@@ -10424,7 +10470,7 @@ def get_column_offset(int column_index=-1):
     unless you call this method.
 
     For a complete example see :func:`columns()`.
-    
+
     Legacy Columns API (2020: prefer using Tables!)
 
     Args:
@@ -10444,7 +10490,7 @@ def set_column_offset(int column_index, float offset_x):
     contents region). Pass -1 to use current column.
 
     For a complete example see :func:`columns()`.
-    
+
     Legacy Columns API (2020: prefer using Tables!)
 
     Args:
@@ -10461,7 +10507,7 @@ def get_column_width(int column_index=-1):
     """Return the column width.
 
     For a complete example see :func:`columns()`.
-    
+
     Legacy Columns API (2020: prefer using Tables!)
 
     Args:
@@ -10478,7 +10524,7 @@ def set_column_width(int column_index, float width):
     contents region). Pass -1 to use current column.
 
     For a complete example see :func:`columns()`.
-    
+
     Legacy Columns API (2020: prefer using Tables!)
 
     Args:
@@ -10495,7 +10541,7 @@ def get_columns_count():
     """Get count of the columns in the current table.
 
     For a complete example see :func:`columns()`.
-    
+
     Legacy Columns API (2020: prefer using Tables!)
 
     Returns:
@@ -10527,30 +10573,35 @@ cdef class _BeginEndTabBar(object):
             self.__class__.__name__, self.opened
         )
 
+    def __eq__(self, other):
+        if other.__class__ is self.__class__:
+            return self.opened is other.opened
+        return self.opened is other
+
 
 def begin_tab_bar(str identifier, cimgui.ImGuiTabBarFlags flags = 0):
     """Create and append into a TabBar
-    
+
     Args:
         identifier(str): String identifier of the tab window
         flags: ImGuiTabBarFlags flags. See:
             :ref:`list of available flags <tabbar-flag-options>`.
-    
+
     Returns:
         bool: True if the Tab Bar is open
-        
+
     .. wraps::
         bool BeginTabBar(const char* str_id, ImGuiTabBarFlags flags = 0)
-    
+
     """
     return _BeginEndTabBar.__new__(
         _BeginEndTabBar,
         cimgui.BeginTabBar(_bytes(identifier), flags)
     )
-    
+
 def end_tab_bar():
     """Only call end_tab_bar() if begin_tab_bar() returns true!
-    
+
     .. wraps::
         void EndTabBar()
     """
@@ -10582,27 +10633,33 @@ cdef class _BeginEndTabItem(object):
             self.__class__.__name__, self.selected, self.opened
         )
 
+    def __eq__(self, other):
+        if other.__class__ is self.__class__:
+            return (self.selected, self.opened) == (other.selected, other.opened)
+        return (self.selected, self.opened) == other
+
+
 def begin_tab_item(str label, opened = None, cimgui.ImGuiTabItemFlags flags = 0):
-    """Create a Tab. 
-    
+    """Create a Tab.
+
     Args:
         label (str): Label of the tab item
         removable (bool): If True, the tab item can be removed
         flags: ImGuiTabItemFlags flags. See:
             :ref:`list of available flags <tabitem-flag-options>`.
-        
+
     Returns:
         tuple: ``(slected, opened)`` tuple of bools. If tab item is selected
         ``selected==True``. The value of ``opened`` is always True for
         non-removable and open tab items but changes state to False on close
         button click for removable tab items.
-        
+
     .. visual-example::
         :auto_layout:
         :width: 300
-        
+
         opened_state = True
-        
+
         #...
 
         imgui.begin("Example Tab Bar")
@@ -10623,11 +10680,11 @@ def begin_tab_item(str label, opened = None, cimgui.ImGuiTabItemFlags flags = 0)
 
             imgui.end_tab_bar()
         imgui.end()
-    
+
     .. wraps::
         bool BeginTabItem(
-            const char* label, 
-            bool* p_open = NULL, 
+            const char* label,
+            bool* p_open = NULL,
             ImGuiTabItemFlags flags = 0
         )
     """
@@ -10643,74 +10700,74 @@ def begin_tab_item(str label, opened = None, cimgui.ImGuiTabItemFlags flags = 0)
 
 def end_tab_item():
     """Only call end_tab_item() if begin_tab_item() returns true!
-    
+
     .. wraps::
         void EndTabItem()
     """
     cimgui.EndTabItem()
 
 def tab_item_button(str label, cimgui.ImGuiTabItemFlags flags = 0):
-    """Create a Tab behaving like a button. 
+    """Create a Tab behaving like a button.
     Cannot be selected in the tab bar.
-    
+
     Args:
         label (str): Label of the button
         flags: ImGuiTabItemFlags flags. See:
             :ref:`list of available flags <tabitem-flag-options>`.
-    
+
     Returns:
         (bool): Return true when clicked.
-    
+
     .. visual-example:
         :auto_layout:
         :width: 300
-        
+
         imgui.begin("Example Tab Bar")
         if imgui.begin_tab_bar("MyTabBar"):
-            
+
             if imgui.begin_tab_item("Item 1")[0]:
                 imgui.text("Here is the tab content!")
                 imgui.end_tab_item()
-                
+
             if imgui.tab_item_button("Click me!"):
                 print('Clicked!')
-                
+
             imgui.end_tab_bar()
         imgui.end()
-    
+
     .. wraps::
         bool TabItemButton(const char* label, ImGuiTabItemFlags flags = 0)
     """
     return cimgui.TabItemButton(_bytes(label), flags)
-    
+
 def set_tab_item_closed(str tab_or_docked_window_label):
-    """Notify TabBar or Docking system of a closed tab/window ahead (useful to reduce visual flicker on reorderable tab bars). 
-    For tab-bar: call after BeginTabBar() and before Tab submissions. 
+    """Notify TabBar or Docking system of a closed tab/window ahead (useful to reduce visual flicker on reorderable tab bars).
+    For tab-bar: call after BeginTabBar() and before Tab submissions.
     Otherwise call with a window name.
-    
+
     Args:
         tab_or_docked_window_label (str): Label of the targeted tab or docked window
-    
+
     .. visual-example:
         :auto_layout:
         :width: 300
-        
+
         imgui.begin("Example Tab Bar")
         if imgui.begin_tab_bar("MyTabBar"):
-            
+
             if imgui.begin_tab_item("Item 1")[0]:
                 imgui.text("Here is the tab content!")
                 imgui.end_tab_item()
-                
+
             if imgui.begin_tab_item("Item 2")[0]:
                 imgui.text("This item won't whow !")
                 imgui.end_tab_item()
-                
+
             imgui.set_tab_item_closed("Item 2")
-                
+
             imgui.end_tab_bar()
         imgui.end()
-    
+
     .. wraps:
         void SetTabItemClosed(const char* tab_or_docked_window_label)
     """
@@ -10737,6 +10794,11 @@ cdef class _BeginEndDragDropSource(object):
         return "{}(dragging={})".format(
             self.__class__.__name__, self.dragging
         )
+
+    def __eq__(self, other):
+        if other.__class__ is self.__class__:
+            return self.dragging is other.dragging
+        return self.dragging is other
 
 
 def begin_drag_drop_source(cimgui.ImGuiDragDropFlags flags=0):
@@ -10835,6 +10897,11 @@ cdef class _BeginEndDragDropTarget(object):
         return "{}(hovered={})".format(
             self.__class__.__name__, self.hovered
         )
+
+    def __eq__(self, other):
+        if other.__class__ is self.__class__:
+            return self.hovered is other.hovered
+        return self.hovered is other
 
 
 def begin_drag_drop_target():

--- a/tests/test_begin_end_context_managers.py
+++ b/tests/test_begin_end_context_managers.py
@@ -1,0 +1,561 @@
+import logging
+import sys
+
+import pytest
+import imgui
+from imgui import ImGuiError
+
+
+class _TestException(Exception):
+    pass
+
+
+@pytest.fixture
+def context():
+    ctx = imgui.get_current_context()
+    if ctx is not None:
+        imgui.destroy_context(ctx)
+    ctx = imgui.create_context()
+    io = imgui.get_io()
+    io.delta_time = 1.0 / 60.0
+    io.display_size = 300, 300
+
+    # setup default font
+    io.fonts.get_tex_data_as_rgba32()
+    io.fonts.add_font_default()
+    io.fonts.texture_id = 0  # set any texture ID to avoid segfaults
+    return ctx
+
+
+@pytest.fixture
+def frame(context):
+    imgui.new_frame()
+    yield
+    try:
+        imgui.render()
+    except ImGuiError:
+        try:
+            imgui.end_frame()
+        except ImGuiError:
+            pass
+
+
+# ------- BEGIN/END ----------
+def test_begin_okay(frame):
+    imgui.begin("Example: empty window")
+    imgui.end()
+
+
+def test_begin_with(frame):
+    with imgui.begin("Example: empty window") as window:
+        assert isinstance(window.expanded, bool)
+        assert isinstance(window.opened, bool)
+
+
+def test_begin_with_exception(frame):
+    # the real test is that the frame cleanup doesn't crash
+    with pytest.raises(_TestException):
+        with imgui.begin("Example: empty window"):
+            raise _TestException
+
+
+def test_begin_unpacking(frame):
+    expanded, opened = imgui.begin("Example: empty window")
+    assert isinstance(expanded, bool)
+    assert isinstance(opened, bool)
+    imgui.end()
+
+
+# ------- BEGIN_CHILD/END_CHILD ----------
+def test_child_okay(frame):
+    imgui.begin("Example: child region")
+
+    imgui.begin_child("region", 150, -50, border=True)
+    imgui.text("inside region")
+    imgui.end_child()
+
+    imgui.text("outside region")
+    imgui.end()
+
+
+def test_child_with(frame):
+    with imgui.begin("Example: child region"):
+        with imgui.begin_child("region", 150, -50, border=True):
+            imgui.text("inside region")
+        imgui.text("outside region")
+
+
+def test_child_with_exception(frame):
+    # the real test is that the frame cleanup doesn't crash
+    with pytest.raises(_TestException):
+        with imgui.begin("Example: child region"):
+            with imgui.begin_child("region", 150, -50, border=True):
+                raise _TestException
+            imgui.text("outside region")
+
+
+def test_child_as_bool(frame):
+    imgui.begin("Example: child region")
+    child = imgui.begin_child("region", 150, -50, border=True)
+    assert bool(child) is child.visible
+    imgui.end_child()
+    imgui.end()
+
+
+# ------- BEGIN_TOOLTIP/END_TOOLTIP ----------
+def test_tooltip_okay(frame):
+    imgui.begin("Example: tooltip")
+    imgui.button("Click me!")
+    if imgui.is_item_hovered():
+        imgui.begin_tooltip()
+        imgui.text("This button is clickable.")
+        imgui.end_tooltip()
+    imgui.end()
+
+
+def test_tooltip_with(frame):
+    with imgui.begin("Example: tooltip"):
+        imgui.button("Click me!")
+        if imgui.is_item_hovered():
+            with imgui.begin_tooltip():
+                imgui.text("This button is clickable.")
+
+
+def test_tooltip_with_exception(frame):
+    # the real test is that the frame cleanup doesn't crash
+    with pytest.raises(_TestException):
+        with imgui.begin("Example: tooltip"):
+            imgui.button("Click me!")
+            with imgui.begin_tooltip():
+                raise _TestException
+
+
+# ------- BEGIN_MAIN_MENU_BAR/END_MAIN_MENU_BAR ----------
+def test_main_menu_bar_okay(frame):
+    if imgui.begin_main_menu_bar():
+        imgui.end_main_menu_bar()
+    else:
+        assert False
+
+
+def test_main_menu_bar_with(frame):
+    with imgui.begin_main_menu_bar() as menu:
+        assert menu.opened is True
+
+
+def test_main_menu_bar_with_exception(frame):
+    # the real test is that the frame cleanup doesn't crash
+    with pytest.raises(_TestException):
+        with imgui.begin_main_menu_bar():
+            raise _TestException
+
+
+def test_main_menu_bar_as_bool(frame):
+    menu = imgui.begin_main_menu_bar()
+    assert isinstance(menu.opened, bool)
+    assert bool(menu) is menu.opened is True
+    imgui.end_main_menu_bar()
+
+
+# ------- BEGIN_MENU_BAR/END_MENU_BAR ----------
+def test_menu_bar_okay(frame):
+    flags = imgui.WINDOW_MENU_BAR
+    imgui.begin("Child Window - File Browser", flags=flags)
+
+    if imgui.begin_menu_bar():
+        imgui.end_menu_bar()
+    else:
+        assert False
+    imgui.end()
+
+
+def test_menu_bar_with(frame):
+    flags = imgui.WINDOW_MENU_BAR
+    with imgui.begin("Child Window - File Browser", flags=flags):
+        with imgui.begin_menu_bar():
+            pass
+
+
+def test_menu_bar_with_exception(frame):
+    # the real test is that the frame cleanup doesn't crash
+    with pytest.raises(_TestException):
+        flags = imgui.WINDOW_MENU_BAR
+        with imgui.begin("Child Window - File Browser", flags=flags):
+            with imgui.begin_menu_bar():
+                raise _TestException
+
+
+def test_menu_bar_as_bool(frame):
+    flags = imgui.WINDOW_MENU_BAR
+    imgui.begin("Child Window - File Browser", flags=flags)
+    menu = imgui.begin_menu_bar()
+    assert isinstance(menu.opened, bool)
+    assert bool(menu) is menu.opened is True
+    imgui.end_menu_bar()
+    imgui.end()
+
+
+# ------- BEGIN_TAB_BAR/END_TAB_BAR ----------
+def test_tab_bar_okay(frame):
+    imgui.begin("Example Tab Bar")
+    if imgui.begin_tab_bar("MyTabBar"):
+        imgui.end_tab_bar()
+    imgui.end()
+
+
+def test_tab_bar_with(frame):
+    with imgui.begin("Example Tab Bar"):
+        with imgui.begin_tab_bar("MyTabBar"):
+            pass
+
+
+def test_tab_bar_with_exception(frame):
+    # the real test is that the frame cleanup doesn't crash
+    with pytest.raises(_TestException):
+        with imgui.begin("Example Tab Bar"):
+            with imgui.begin_tab_bar("MyTabBar"):
+                raise _TestException
+
+
+def test_tab_bar_as_bool(frame):
+    imgui.begin("Example Tab Bar")
+    tab_bar = imgui.begin_tab_bar("MyTabBar")
+    assert bool(tab_bar) is tab_bar.opened is True
+    imgui.end_tab_bar()
+    imgui.end()
+
+
+# ------- BEGIN_TAB_ITEM/END_TAB_ITEM ----------
+def test_tab_item_okay(frame):
+    imgui.begin("Example Tab Bar")
+    if imgui.begin_tab_bar("MyTabBar"):
+        if imgui.begin_tab_item("Item 1")[0]:
+            imgui.text("Here is the tab content!")
+            imgui.end_tab_item()
+        imgui.end_tab_bar()
+    imgui.end()
+
+
+def test_tab_item_with(frame):
+    with imgui.begin("Example Tab Bar"):
+        with imgui.begin_tab_bar("MyTabBar") as tab_bar:
+            if tab_bar.opened:
+                with imgui.begin_tab_item("Item 1") as item:
+                    if item.selected:
+                        pass
+
+
+def test_tab_item_with_exception(frame):
+    # the real test is that the frame cleanup doesn't crash
+    with pytest.raises(_TestException):
+        with imgui.begin("Example Tab Bar"):
+            with imgui.begin_tab_bar("MyTabBar") as tab_bar:
+                if tab_bar.opened:
+                    with imgui.begin_tab_item("Item 1") as item:
+                        raise _TestException
+
+
+def test_tab_item_as_bool(frame):
+    imgui.begin("Example Tab Bar")
+    tab_bar = imgui.begin_tab_bar("MyTabBar")
+    assert tab_bar.opened
+    item = imgui.begin_tab_item("Item 1")
+    assert bool(item) is item.selected is True
+    assert item.opened is False
+    imgui.end_tab_item()
+    imgui.end_tab_bar()
+    imgui.end()
+
+
+# ------- BEGIN_MENU/END_MENU ----------
+def test_menu_okay(frame):
+    flags = imgui.WINDOW_MENU_BAR
+    imgui.begin("Child Window - File Browser", flags=flags)
+
+    if imgui.begin_menu_bar():
+        if imgui.begin_menu('File'):
+            imgui.menu_item('Close')
+            imgui.end_menu()
+        imgui.end_menu_bar()
+    imgui.end()
+
+
+def test_menu_with(frame):
+    flags = imgui.WINDOW_MENU_BAR
+    with imgui.begin("Child Window - File Browser", flags=flags):
+        with imgui.begin_menu_bar() as menu_bar:
+            if menu_bar.opened:
+                with imgui.begin_menu('File'):
+                    pass
+
+
+def test_menu_with_exception(frame):
+    # the real test is that the frame cleanup doesn't crash
+    with pytest.raises(_TestException):
+        flags = imgui.WINDOW_MENU_BAR
+        with imgui.begin("Child Window - File Browser", flags=flags):
+            with imgui.begin_menu_bar() as menu_bar:
+                if menu_bar.opened:
+                    with imgui.begin_menu('File'):
+                        raise _TestException
+
+
+def test_menu_as_bool(frame):
+    flags = imgui.WINDOW_MENU_BAR
+    imgui.begin("Child Window - File Browser", flags=flags)
+    menu_bar = imgui.begin_menu_bar()
+    assert menu_bar.opened
+    menu = imgui.begin_menu('File')
+    assert isinstance(menu.opened, bool)
+    assert bool(menu) is menu.opened is False
+    imgui.end_menu_bar()
+    imgui.end()
+
+
+# ------- BEGIN_POPUP{,_CONTEXT_ITEM,_CONTEXT_WINDOW,_CONTEXT_VOID}/END_POPUP ----------
+def test_popup_okay(frame):
+    imgui.begin("Example: simple popup")
+    imgui.open_popup("select-popup")
+    if imgui.begin_popup("select-popup"):
+        imgui.end_popup()
+    imgui.end()
+
+
+def test_popup_with(frame):
+    with imgui.begin("Example: simple popup"):
+        imgui.open_popup("select-popup")
+        with imgui.begin_popup("select-popup"):
+            pass
+
+
+def test_popup_with_exception(frame):
+    # the real test is that the frame cleanup doesn't crash
+    with pytest.raises(_TestException):
+        with imgui.begin("Example: simple popup"):
+            imgui.open_popup("select-popup")
+            with imgui.begin_popup("select-popup"):
+                raise _TestException
+
+
+def test_popup_as_bool(frame):
+    imgui.begin("Example: simple popup")
+    imgui.open_popup("select-popup")
+    popup = imgui.begin_popup("select-popup")
+    assert isinstance(popup.opened, bool)
+    assert bool(popup) is popup.opened is True
+    imgui.end_popup()
+    imgui.end()
+
+
+def test_popup_context_item_isinstance(frame):
+    imgui.begin("Example: popup context view")
+    imgui.text("Right-click to set value.")
+    item = imgui.begin_popup_context_item("Item Context Menu")
+    assert isinstance(item, imgui.core._BeginEndPopup)
+    assert item.opened is False
+    imgui.end()
+
+
+def test_popup_context_window_isinstance(frame):
+    imgui.begin("Example: popup context window")
+    window = imgui.begin_popup_context_window()
+    assert isinstance(window, imgui.core._BeginEndPopup)
+    assert window.opened is False
+    imgui.end()
+
+
+def test_popup_context_void_isinstance(frame):
+    window = imgui.begin_popup_context_void()
+    assert isinstance(window, imgui.core._BeginEndPopup)
+    assert window.opened is False
+
+
+# ------- BEGIN_POPUP_MODAL/END_POPUP_MODAL ----------
+def test_popup_modal_okay(frame):
+    imgui.begin("Example: simple popup modal")
+    imgui.open_popup("select-popup")
+    if imgui.begin_popup_modal("select-popup")[0]:
+        imgui.end_popup()
+    imgui.end()
+
+
+def test_popup_modal_with(frame):
+    with imgui.begin("Example: simple popup modal"):
+        imgui.open_popup("select-popup")
+        with imgui.begin_popup_modal("select-popup"):
+            pass
+
+
+def test_popup_modal_with_exception(frame):
+    # the real test is that the frame cleanup doesn't crash
+    with pytest.raises(_TestException):
+        with imgui.begin("Example: simple popup modal"):
+            imgui.open_popup("select-popup")
+            with imgui.begin_popup_modal("select-popup"):
+                raise _TestException
+
+
+def test_popup_modal_as_bool(frame):
+    imgui.begin("Example: simple popup modal")
+    imgui.open_popup("select-popup")
+    popup = imgui.begin_popup_modal("select-popup")
+    assert popup.opened is True
+    assert popup.visible is False
+    opened, visible = popup
+    assert opened is popup.opened is popup[0]
+    assert visible is popup.visible is popup[1]
+    imgui.end_popup()
+    imgui.end()
+
+
+# ------- BEGIN_DRAG_DROP_SOURCE/END_DRAG_DROP_SOURCE ----------
+def test_drag_drop_source_okay(frame):
+    imgui.begin("Example: drag and drop")
+    imgui.button('source')
+    if imgui.begin_drag_drop_source():
+        imgui.set_drag_drop_payload('itemtype', b'payload')
+        imgui.end_drag_drop_source()
+    imgui.end()
+
+
+def test_drag_drop_source_with(frame):
+    with imgui.begin("Example: drag and drop"):
+        imgui.button('source')
+        with imgui.begin_drag_drop_source():
+            pass
+
+
+def test_drag_drop_source_with_exception(frame):
+    # the real test is that the frame cleanup doesn't crash
+    with pytest.raises(_TestException):
+        with imgui.begin("Example: drag and drop"):
+            imgui.button('source')
+            with imgui.begin_drag_drop_source():
+                raise _TestException
+
+
+def test_drag_drop_source_as_bool(frame):
+    imgui.begin("Example: drag and drop")
+    imgui.button('source')
+    src = imgui.begin_drag_drop_source()
+    assert bool(src) is src.dragging is False
+    imgui.end()
+
+
+# ------- BEGIN_DRAG_DROP_TARGET/END_DRAG_DROP_TARGET ----------
+def test_drag_drop_target_okay(frame):
+    imgui.begin("Example: drag and drop")
+    imgui.button('dest')
+    if imgui.begin_drag_drop_target():
+        payload = imgui.accept_drag_drop_payload('itemtype')
+        imgui.end_drag_drop_target()
+    imgui.end()
+
+
+def test_drag_drop_target_with(frame):
+    with imgui.begin("Example: drag and drop"):
+        imgui.button('dest')
+        with imgui.begin_drag_drop_target():
+            pass
+
+
+def test_drag_drop_target_with_exception(frame):
+    # the real test is that the frame cleanup doesn't crash
+    with pytest.raises(_TestException):
+        with imgui.begin("Example: drag and drop"):
+            imgui.button('dest')
+            with imgui.begin_drag_drop_target():
+                raise _TestException
+
+
+def test_drag_drop_target_as_bool(frame):
+    imgui.begin("Example: drag and drop")
+    imgui.button('dest')
+    target = imgui.begin_drag_drop_target()
+    assert bool(target) is target.hovered is False
+    imgui.end()
+
+
+# ------- BEGIN_GROUP/END_GROUP ----------
+def test_group_okay(frame):
+    imgui.begin("Example: item groups")
+    imgui.begin_group()
+    imgui.text("First group (buttons):")
+    imgui.end_group()
+    imgui.end()
+
+
+def test_group_with(frame):
+    with imgui.begin("Example: item groups"):
+        with imgui.begin_group():
+            imgui.text("First group (buttons):")
+
+
+def test_group_with_exception(frame):
+    # the real test is that the frame cleanup doesn't crash
+    with pytest.raises(_TestException):
+        with imgui.begin("Example: item groups"):
+            with imgui.begin_group():
+                raise _TestException
+
+
+# ------- BEGIN_LIST_BOX/END_LIST_BOX ----------
+def test_list_box_okay(frame):
+    imgui.begin("Example: custom listbox")
+    if imgui.begin_list_box("List", 200, 100):
+        imgui.selectable("Selected", True)
+        imgui.selectable("Not Selected", False)
+        imgui.end_list_box()
+    imgui.end()
+
+
+def test_list_box_with(frame):
+    with imgui.begin("Example: custom listbox"):
+        with imgui.begin_list_box("List", 200, 100):
+            pass
+
+
+def test_list_box_with_exception(frame):
+    # the real test is that the frame cleanup doesn't crash
+    with pytest.raises(_TestException):
+        with imgui.begin("Example: custom listbox"):
+            with imgui.begin_list_box("List", 200, 100):
+                raise _TestException
+
+
+def test_list_box_as_bool(frame):
+    imgui.begin("Example: custom listbox")
+    list_box = imgui.begin_list_box("List", 200, 100)
+    assert bool(list_box) is list_box.opened is True
+    imgui.end_list_box()
+    imgui.end()
+
+
+# ------- BEGIN_TABLE/END_TABLE ----------
+def test_table_okay(frame):
+    imgui.begin("Example: table")
+    if imgui.begin_table("data", 2):
+        imgui.end_table()
+    imgui.end()
+
+
+def test_table_with(frame):
+    with imgui.begin("Example: table"):
+        with imgui.begin_table("data", 2):
+            pass
+
+
+def test_table_with_exception(frame):
+    # the real test is that the frame cleanup doesn't crash
+    with pytest.raises(_TestException):
+        with imgui.begin("Example: table"):
+            with imgui.begin_table("data", 2):
+                raise _TestException
+
+
+def test_table_as_bool(frame):
+    imgui.begin("Example: table")
+    table = imgui.begin_table("data", 2)
+    assert bool(table) is table.opened is True
+    imgui.end_table()
+    imgui.end()

--- a/tests/test_begin_end_context_managers.py
+++ b/tests/test_begin_end_context_managers.py
@@ -66,6 +66,12 @@ def test_begin_unpacking(frame):
     imgui.end()
 
 
+def test_begin_equality(frame):
+    window = imgui.begin("Example: empty window")
+    assert window == window
+    assert window == tuple(window)
+    imgui.end()
+
 # ------- BEGIN_CHILD/END_CHILD ----------
 def test_child_okay(frame):
     imgui.begin("Example: child region")
@@ -98,6 +104,8 @@ def test_child_as_bool(frame):
     imgui.begin("Example: child region")
     child = imgui.begin_child("region", 150, -50, border=True)
     assert bool(child) is child.visible
+    assert child == child
+    assert child == bool(child)
     imgui.end_child()
     imgui.end()
 
@@ -154,6 +162,8 @@ def test_main_menu_bar_as_bool(frame):
     menu = imgui.begin_main_menu_bar()
     assert isinstance(menu.opened, bool)
     assert bool(menu) is menu.opened is True
+    assert menu == menu
+    assert menu == bool(menu)
     imgui.end_main_menu_bar()
 
 
@@ -191,6 +201,8 @@ def test_menu_bar_as_bool(frame):
     menu = imgui.begin_menu_bar()
     assert isinstance(menu.opened, bool)
     assert bool(menu) is menu.opened is True
+    assert menu == menu
+    assert menu == bool(menu)
     imgui.end_menu_bar()
     imgui.end()
 
@@ -221,6 +233,8 @@ def test_tab_bar_as_bool(frame):
     imgui.begin("Example Tab Bar")
     tab_bar = imgui.begin_tab_bar("MyTabBar")
     assert bool(tab_bar) is tab_bar.opened is True
+    assert tab_bar == tab_bar
+    assert tab_bar == bool(tab_bar)
     imgui.end_tab_bar()
     imgui.end()
 
@@ -262,6 +276,8 @@ def test_tab_item_as_bool(frame):
     item = imgui.begin_tab_item("Item 1")
     assert bool(item) is item.selected is True
     assert item.opened is False
+    assert item == item
+    assert item == tuple(item)
     imgui.end_tab_item()
     imgui.end_tab_bar()
     imgui.end()
@@ -308,6 +324,8 @@ def test_menu_as_bool(frame):
     menu = imgui.begin_menu('File')
     assert isinstance(menu.opened, bool)
     assert bool(menu) is menu.opened is False
+    assert menu == menu
+    assert menu == bool(menu)
     imgui.end_menu_bar()
     imgui.end()
 
@@ -343,6 +361,8 @@ def test_popup_as_bool(frame):
     popup = imgui.begin_popup("select-popup")
     assert isinstance(popup.opened, bool)
     assert bool(popup) is popup.opened is True
+    assert popup == popup
+    assert popup == bool(popup)
     imgui.end_popup()
     imgui.end()
 
@@ -353,6 +373,8 @@ def test_popup_context_item_isinstance(frame):
     item = imgui.begin_popup_context_item("Item Context Menu")
     assert isinstance(item, imgui.core._BeginEndPopup)
     assert item.opened is False
+    assert item == item
+    assert item == bool(item)
     imgui.end()
 
 
@@ -361,6 +383,8 @@ def test_popup_context_window_isinstance(frame):
     window = imgui.begin_popup_context_window()
     assert isinstance(window, imgui.core._BeginEndPopup)
     assert window.opened is False
+    assert window == window
+    assert window == bool(window)
     imgui.end()
 
 
@@ -368,6 +392,8 @@ def test_popup_context_void_isinstance(frame):
     window = imgui.begin_popup_context_void()
     assert isinstance(window, imgui.core._BeginEndPopup)
     assert window.opened is False
+    assert window == window
+    assert window == bool(window)
 
 
 # ------- BEGIN_POPUP_MODAL/END_POPUP_MODAL ----------
@@ -404,6 +430,8 @@ def test_popup_modal_as_bool(frame):
     opened, visible = popup
     assert opened is popup.opened is popup[0]
     assert visible is popup.visible is popup[1]
+    assert popup == popup
+    assert popup == tuple(popup)
     imgui.end_popup()
     imgui.end()
 
@@ -439,6 +467,8 @@ def test_drag_drop_source_as_bool(frame):
     imgui.button('source')
     src = imgui.begin_drag_drop_source()
     assert bool(src) is src.dragging is False
+    assert src == src
+    assert src == bool(src)
     imgui.end()
 
 
@@ -473,6 +503,8 @@ def test_drag_drop_target_as_bool(frame):
     imgui.button('dest')
     target = imgui.begin_drag_drop_target()
     assert bool(target) is target.hovered is False
+    assert target == target
+    assert target == bool(target)
     imgui.end()
 
 
@@ -527,6 +559,8 @@ def test_list_box_as_bool(frame):
     imgui.begin("Example: custom listbox")
     list_box = imgui.begin_list_box("List", 200, 100)
     assert bool(list_box) is list_box.opened is True
+    assert list_box == list_box
+    assert list_box == bool(list_box)
     imgui.end_list_box()
     imgui.end()
 
@@ -557,5 +591,7 @@ def test_table_as_bool(frame):
     imgui.begin("Example: table")
     table = imgui.begin_table("data", 2)
     assert bool(table) is table.opened is True
+    assert table == table
+    assert table == bool(table)
     imgui.end_table()
     imgui.end()


### PR DESCRIPTION
See: https://github.com/pyimgui/pyimgui/issues/255

I've added context manager support for all 18 begin/end pairs. I don't see this as a replacement for the old style, but as a complementary style. Old code should continue to work as is. New code that wants/needs to handle exceptions can use the context managers to ensure the imgui stack is not corrupted.

The changes are backwards compatible in the following sense:

0. Changes were implemented using raw Cython cdef classes, so they should be compatible with all supported Python versions (even 2.7, which I personally would drop support for *wink*).
1. Return values that were tuples have __getitem__ and __iter__ methods that return tuple getitem and tuple iter.
2. Return values that were bools have __bool__ that returns the old return value.
3. Return values that were None were assumed to not be used previously, so nothing was done to make them backwards compatible.

I've added extensive testing for all of the things added/changed. The biggest thing missing would be to update the documentation, but I'd like to get feedback before attempting to do that.

Edit: See https://cython.readthedocs.io/en/latest/src/userguide/extension_types.html#fast-instantiation for why I use the __cinit__ + __new__ trick.