### PR TITLE
Skip with statements automatically where needed

### DIFF
--- a/imgui/_skipwith.py
+++ b/imgui/_skipwith.py
@@ -1,0 +1,73 @@
+import io
+import sys
+import inspect
+
+
+class SkipWithStatement(Exception):
+    pass
+
+
+def raise_skip_with_statement(*args, **kwargs):
+    raise SkipWithStatement()
+
+
+def _settrace(func):
+    # Pydev actually writes to stderr instead of using a warning...
+    stderr, sys.stderr = sys.stderr, io.StringIO()
+    sys.settrace(func)
+    sys.stderr = stderr
+
+
+class SkipWith(object):
+    def __init__(self, context, should_skip):
+        self._should_skip = should_skip
+        self._context = context
+        self._orig_trace = None
+        self._skipped = False
+
+    def __enter__(self):
+        context_enter = self._context.__enter__()
+
+        if self._should_skip:
+            # Need to set trace to trigger the frame trace. Also need to reset trace after trace errors.
+            self._orig_trace = sys.gettrace()
+            if self._orig_trace is None:
+                _settrace(lambda *args, **keys: None)
+
+            # Set a stack trace that will raise an error to skip the context block.
+            frame = inspect.currentframe().f_back
+            frame.f_trace = raise_skip_with_statement
+            self._skipped = True
+
+        return context_enter
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        # Reset the original trace method to resume debugging.
+        if self._skipped:
+            _settrace(self._orig_trace)
+            self._orig_trace = None
+
+        context_exit = self._context.__exit__(exc_type, exc_val, exc_tb)
+        if exc_type == SkipWithStatement:
+            # Truthy return from __exit__ suppresses the error.
+            return True
+        else:
+            # Otherwise return the wrapped __exit__ result.
+            return context_exit
+
+    # For legacy support
+
+    def __getitem__(self, item):
+        return self._context.__getitem__(item)
+
+    def __iter__(self):
+        return self._context.__iter__()
+
+    def __repr__(self):
+        return self._context.__repr__()
+
+    def __eq__(self, other):
+        return self._context.__eq__(other)
+
+    def __bool__(self):
+        return self._context.__bool__()

--- a/imgui/core.pyx
+++ b/imgui/core.pyx
@@ -12,6 +12,8 @@ import cython
 from cython.view cimport array as cvarray
 from cython.operator cimport dereference as deref
 
+from imgui._skipwith import SkipWith
+
 from collections import namedtuple
 import warnings
 from contextlib import contextmanager
@@ -4680,12 +4682,16 @@ def begin_list_box(
         )
 
     """
-    return _BeginEndListBox.__new__(
-        _BeginEndListBox,
-        cimgui.BeginListBox(
+    opened = cimgui.BeginListBox(
             _bytes(label),
             _cast_args_ImVec2(width, height)
         )
+    return SkipWith(
+        _BeginEndListBox.__new__(
+            _BeginEndListBox,
+            opened
+        ),
+        not opened
     )
 
 def listbox_header( # OBSOLETED in 1.81 (from February 2021)
@@ -4929,9 +4935,13 @@ def begin_main_menu_bar():
     .. wraps::
         bool BeginMainMenuBar()
     """
-    return _BeginEndMainMenuBar.__new__(
-        _BeginEndMainMenuBar,
-        cimgui.BeginMainMenuBar()
+    opened = cimgui.BeginMainMenuBar()
+    return SkipWith(
+        _BeginEndMainMenuBar.__new__(
+            _BeginEndMainMenuBar,
+            opened
+        ),
+        not opened
     )
 
 
@@ -5037,9 +5047,13 @@ def begin_menu_bar():
     .. wraps::
         bool BeginMenuBar()
     """
-    return _BeginEndMenuBar.__new__(
-        _BeginEndMenuBar,
-        cimgui.BeginMenuBar()
+    opened = cimgui.BeginMenuBar()
+    return SkipWith(
+        _BeginEndMenuBar.__new__(
+            _BeginEndMenuBar,
+            opened
+        ),
+        not opened
     )
 
 
@@ -5121,9 +5135,13 @@ def begin_menu(str label, enabled=True):
             bool enabled
         )
     """
-    return _BeginEndMenu.__new__(
-        _BeginEndMenu,
-        cimgui.BeginMenu(_bytes(label), enabled)
+    opened = cimgui.BeginMenu(_bytes(label), enabled)
+    return SkipWith(
+        _BeginEndMenu.__new__(
+            _BeginEndMenu,
+            opened
+        ),
+        not opened
     )
 
 
@@ -5349,9 +5367,13 @@ def begin_popup(str label, cimgui.ImGuiWindowFlags flags=0):
             ImGuiWindowFlags flags = 0
         )
     """
-    return _BeginEndPopup.__new__(
-        _BeginEndPopup,
-        cimgui.BeginPopup(_bytes(label), flags)
+    opened = cimgui.BeginPopup(_bytes(label), flags)
+    return SkipWith(
+        _BeginEndPopup.__new__(
+            _BeginEndPopup,
+            opened
+        ),
+        not opened
     )
 
 
@@ -5475,14 +5497,18 @@ def begin_popup_modal(str title, visible=None, cimgui.ImGuiWindowFlags flags=0):
     """
     cdef cimgui.bool inout_visible = visible
 
-    return _BeginEndPopupModal.__new__(
-        _BeginEndPopupModal,
-        cimgui.BeginPopupModal(
+    opened = cimgui.BeginPopupModal(
             _bytes(title),
             &inout_visible if visible is not None else NULL,
             flags
+    )
+    return SkipWith(
+        _BeginEndPopupModal.__new__(
+            _BeginEndPopupModal,
+            opened,
+            inout_visible
         ),
-        inout_visible
+        not opened
     )
 
 
@@ -5730,15 +5756,19 @@ def begin_table(
             float inner_width = 0.0f
         )
     """
-    return _BeginEndTable.__new__(
-        _BeginEndTable,
-        cimgui.BeginTable(
+    opened = cimgui.BeginTable(
             _bytes(label),
             column,
             flags,
             _cast_args_ImVec2(outer_size_width, outer_size_height),
             inner_width
         )
+    return SkipWith(
+        _BeginEndTable.__new__(
+            _BeginEndTable,
+            opened
+        ),
+        not opened
     )
 
 def end_table():
@@ -10885,9 +10915,13 @@ def begin_tab_bar(str identifier, cimgui.ImGuiTabBarFlags flags = 0):
         bool BeginTabBar(const char* str_id, ImGuiTabBarFlags flags = 0)
 
     """
-    return _BeginEndTabBar.__new__(
-        _BeginEndTabBar,
-        cimgui.BeginTabBar(_bytes(identifier), flags)
+    opened = cimgui.BeginTabBar(_bytes(identifier), flags)
+    return SkipWith(
+        _BeginEndTabBar.__new__(
+            _BeginEndTabBar,
+            opened
+        ),
+        not opened
     )
 
 def end_tab_bar():
@@ -11020,13 +11054,17 @@ def begin_tab_item(str label, opened = None, cimgui.ImGuiTabItemFlags flags = 0)
         )
     """
     cdef cimgui.bool inout_opened = opened
-    return _BeginEndTabItem.__new__(
-        _BeginEndTabItem,
-        cimgui.BeginTabItem(
+    selected = cimgui.BeginTabItem(
             _bytes(label),
             &inout_opened if opened is not None else NULL, flags
+    )
+    return SkipWith(
+        _BeginEndTabItem.__new__(
+            _BeginEndTabItem,
+            selected,
+            inout_opened
         ),
-        inout_opened
+        not selected
     )
 
 def end_tab_item():
@@ -11202,9 +11240,13 @@ def begin_drag_drop_source(cimgui.ImGuiDragDropFlags flags=0):
     .. wraps::
         bool BeginDragDropSource(ImGuiDragDropFlags flags = 0)
     """
-    return _BeginEndDragDropSource.__new__(
-        _BeginEndDragDropSource,
-        cimgui.BeginDragDropSource(flags)
+    dragging = cimgui.BeginDragDropSource(flags)
+    return SkipWith(
+        _BeginEndDragDropSource.__new__(
+            _BeginEndDragDropSource,
+            dragging
+        ),
+        not dragging
     )
 
 
@@ -11299,9 +11341,13 @@ def begin_drag_drop_target():
     .. wraps::
         bool BeginDragDropTarget()
     """
-    return _BeginEndDragDropTarget.__new__(
-        _BeginEndDragDropTarget,
-        cimgui.BeginDragDropTarget()
+    hovered = cimgui.BeginDragDropTarget()
+    return SkipWith(
+        _BeginEndDragDropTarget.__new__(
+            _BeginEndDragDropTarget,
+            hovered
+        ),
+        not hovered
     )
 
 


### PR DESCRIPTION
While the `with` context managers are very useful, it is annoying to have to remember the `if xyz.opened` and analogous, and also the double indentation can get in the way. The solution outlined towards the end of #255 would solve this but it is not that ideal since it still requires the user to remember to raise the exception, and also it is worse in terms of readability.

I discovered a [project](https://github.com/justengel/conditional_context) that allowed skipping `with` blocks using dark magic (I'm not 100% sure on what exactly it does, but my best understanding is that it modifies the system trace to make python think the exception was raised just inside the `with` block, and then discards the exception in `__exit__`) and tried to adapt it to wrap an existing context manager.

This PR implements `imgui._skipwith.SkipWith(context, should_skip)`, an internal class used to wrap an existing imgui context manager (first argument) and optionally skip the `with` block body based on a condition (second argument). When applied to the relevant context managers this is the result:

Continues to work:
```python
imgui.begin("Popup Example")
if imgui.button("Open Modal Popup"):
    imgui.open_popup("Modal Popup")
if imgui.begin_popup_modal("Modal Popup")[0]:
    imgui.text("Select an option:")
    imgui.separator()
    imgui.selectable("Red Pill")
    imgui.selectable("Blue Pill")
    imgui.end_popup()
imgui.end()
```
Also continues to work (behavior of #255):
```python
with imgui.begin("Popup Example"):
    if imgui.button("Open Modal Popup"):
        imgui.open_popup("Modal Popup")
    with imgui.begin_popup_modal("Modal Popup") as popup:
        if popup.opened:
            # Double indentation, additional if check
            imgui.text("Select an option:")
            imgui.separator()
            imgui.selectable("Red Pill")
            imgui.selectable("Blue Pill")
```
Can be rewritten as:
```python
with imgui.begin("Popup Example"):
    if imgui.button("Open Modal Popup"):
        imgui.open_popup("Modal Popup")
    with imgui.begin_popup_modal("Modal Popup"):
        # No need to check popup.opened
        # This 'with' block gets skipped if opened is False
        imgui.text("Select an option:")
        imgui.separator()
        imgui.selectable("Red Pill")
        imgui.selectable("Blue Pill")
```