### PR TITLE
Update imgui-cpp submodule to 505f19e3b00 (docking, ocornut 2022-04-05)

### DIFF
--- a/ansifeed-cpp/AnsiTextColored.cpp
+++ b/ansifeed-cpp/AnsiTextColored.cpp
@@ -515,7 +515,7 @@ namespace ImGui
                 if (line < text_end) {
                     ImRect line_rect(pos, pos + ImVec2(FLT_MAX, line_height));
                     while (line < text_end) {
-                        if (IsClippedEx(line_rect, 0, false)) // for future: if (IsClippedEx(line_rect, 0))
+                        if (IsClippedEx(line_rect, 0))
                             break;
 
                         const char* line_end = (const char*)memchr(line, '\n', text_end - line);

--- a/doc/examples/testwindow.py
+++ b/doc/examples/testwindow.py
@@ -2517,7 +2517,7 @@ def show_test_window():
             # imgui.drag_float("float##2", &f);
             # imgui.pop_item_width();
 
-            # imgui.text("PushItemWidth(GetContentRegionAvailWidth() * 0.5f)");
+            # imgui.text("PushItemWidth(ImGui::GetContentRegionAvail().x * 0.5f)");
             # imgui.same_line();
             # ShowHelpMarker("Half of available width.\n(~ right-cursor_pos)\n(works within a column set)");
             # imgui.push_item_width(imgui.get_content_region_avail_width() * 0.5f);

--- a/imgui/cimgui.pxd
+++ b/imgui/cimgui.pxd
@@ -1139,7 +1139,6 @@ cdef extern from "imgui.h" namespace "ImGui":
     # Content region
     ImVec2 GetContentRegionAvail() except +  # ✓
     ImVec2 GetContentRegionMax() except +  # ✓
-    float GetContentRegionAvailWidth() except +  # ✓ # OBSOLETED in 1.70 (from May 2019)
     ImVec2 GetWindowContentRegionMin() except +  # ✓
     ImVec2 GetWindowContentRegionMax() except +  # ✓
     float GetWindowContentRegionWidth() except +  # ✓

--- a/imgui/core.pyx
+++ b/imgui/core.pyx
@@ -187,7 +187,8 @@ COLOR_EDIT_PICKER_HUE_WHEEL = enums.ImGuiColorEditFlags_PickerHueWheel
 COLOR_EDIT_INPUT_RGB = enums.ImGuiColorEditFlags_InputRGB        
 COLOR_EDIT_INPUT_HSV = enums.ImGuiColorEditFlags_InputHSV        
 
-COLOR_EDIT_DEFAULT_OPTIONS = enums.ImGuiColorEditFlags__OptionsDefault
+COLOR_EDIT_DEFAULT_OPTIONS = enums.ImGuiColorEditFlags_DefaultOptions_
+
 
 # ==== TreeNode flags enum redefines ====
 TREE_NODE_NONE = enums.ImGuiTreeNodeFlags_None
@@ -3607,19 +3608,6 @@ def get_content_region_available():
         ImVec2 GetContentRegionMax()
     """
     return _cast_ImVec2_tuple(cimgui.GetContentRegionAvail())
-
-
-# OBSOLETED in 1.70 (from May 2019)
-def get_content_region_available_width():
-    """Get available content region width.
-
-    Returns:
-        float: available content region width.
-
-    .. wraps::
-        float GetContentRegionAvailWidth()
-    """
-    return cimgui.GetContentRegionAvailWidth()
 
 
 def get_window_content_region_min():

--- a/imgui/enums.pxd
+++ b/imgui/enums.pxd
@@ -259,7 +259,7 @@ cdef extern from "imgui.h":
 
         # Defaults Options. You can set application defaults using SetColorEditOptions(). The intent is that you probably don't want to
         # override them in most of your calls. Let the user choose via the option menu and/or call SetColorEditOptions() once during startup.
-        ImGuiColorEditFlags__OptionsDefault = ImGuiColorEditFlags_Uint8 | ImGuiColorEditFlags_DisplayRGB | ImGuiColorEditFlags_InputRGB | ImGuiColorEditFlags_PickerHueBar,
+        ImGuiColorEditFlags_DefaultOptions_ = ImGuiColorEditFlags_Uint8 | ImGuiColorEditFlags_DisplayRGB | ImGuiColorEditFlags_InputRGB | ImGuiColorEditFlags_PickerHueBar,
 
 
     ctypedef enum ImGuiSliderFlags_:

--- a/imgui/enums_internal.pxd
+++ b/imgui/enums_internal.pxd
@@ -134,8 +134,8 @@ cdef extern from "imgui_internal.h":
         ImGuiNavMoveFlags_WrapY                 # This is not super useful for provided for completeness
         ImGuiNavMoveFlags_AllowCurrentNavId     # Allow scoring and considering the current NavId as a move target candidate. This is used when the move source is offset (e.g. pressing PageDown actually needs to send a Up move request, if we are pressing PageDown from the bottom-most item we need to stay in place)
         ImGuiNavMoveFlags_AlsoScoreVisibleSet   # Store alternate result in NavMoveResultLocalVisibleSet that only comprise elements that are already fully visible.
-        ImGuiNavMoveFlags_ScrollToEdge
-    
+        ImGuiNavMoveFlags_ScrollToEdgeY
+
     ctypedef enum ImGuiNavLayer:
         ImGuiNavLayer_Main  # Main scrolling layer
         ImGuiNavLayer_Menu  # Menu layer (access with Alt/ImGuiNavInput_Menu)

--- a/imgui/internal.pyx
+++ b/imgui/internal.pyx
@@ -146,7 +146,7 @@ NAV_MOVE_WRAP_X = enums_internal.ImGuiNavMoveFlags_WrapX
 NAV_MOVE_WRAP_Y = enums_internal.ImGuiNavMoveFlags_WrapY
 NAV_MOVE_ALLOW_CURRENT_NAV_ID = enums_internal.ImGuiNavMoveFlags_AllowCurrentNavId
 NAV_MOVE_ALSO_SCORE_VISIBLE_SET = enums_internal.ImGuiNavMoveFlags_AlsoScoreVisibleSet
-NAV_MOVE_SCROLL_TO_EDGE = enums_internal.ImGuiNavMoveFlags_ScrollToEdge
+NAV_MOVE_SCROLL_TO_EDGE_Y = enums_internal.ImGuiNavMoveFlags_ScrollToEdgeY
 
 # Nav Layer
 NAV_LAYER_MAIN = enums_internal.ImGuiNavLayer_Main

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ else:  # OS X and Linux
     os_specific_flags = ['-includeconfig-cpp/py_imconfig.h']
     os_specific_macros = []
 
+common_flags = ['-std=c++11']
 
 if _CYTHONIZE_WITH_COVERAGE:
     compiler_directives = {
@@ -120,7 +121,7 @@ EXTRAS_REQUIRE['full'] = list(set(chain(*EXTRAS_REQUIRE.values())))
 EXTENSIONS = [
     Extension(
         "imgui.core", extension_sources("imgui/core"),
-        extra_compile_args=os_specific_flags,
+        extra_compile_args=os_specific_flags + common_flags,
         define_macros=[
             # note: for raising custom exceptions directly in ImGui code
             ('PYIMGUI_CUSTOM_EXCEPTION', None)
@@ -129,7 +130,7 @@ EXTENSIONS = [
     ),
     Extension(
         "imgui.internal", extension_sources("imgui/internal"),
-        extra_compile_args=os_specific_flags,
+        extra_compile_args=os_specific_flags + common_flags,
         define_macros=[
             # note: for raising custom exceptions directly in ImGui code
             ('PYIMGUI_CUSTOM_EXCEPTION', None)


### PR DESCRIPTION
Adaptations done inside pyimgui:
********************************

- setup.py: `common_flags = ['-std=c++11']` addd to `extra_compile_args`
  (required since imgui started to use constexpr)

- `IsClippedEx` new signature:
   => impacts one line in AnsiTextColored.cpp

- `GetContentRegionAvailWidth()` replaced by `GetContentRegionAvail().x`
  => remove declaration in cimgui.pxd and impl in core.pyx,
     adapt one commented line in testwindow.py,

- `ImGuiColorEditFlags__OptionsDefault` renamed to
  `ImGuiColorEditFlags_DefaultOptions_`
   => one line changed in core.pyx and enums.pxd

- `ImGuiNavMoveFlags_ScrollToEdge` renamed to
  `ImGuiNavMoveFlags_ScrollToEdgeY`
   => renamed `NAV_MOVE_SCROLL_TO_EDGE` to
              `NAV_MOVE_SCROLL_TO_EDGE_Y`
      inside internal.pyx and enums_internal.pxd,