### PR TITLE
Fix typo and value / type switch error

### DIFF
--- a/imgui/core.pyx
+++ b/imgui/core.pyx
@@ -5635,7 +5635,7 @@ def is_popup_open( str label,  cimgui.ImGuiPopupFlags flags = 0):
     .. wraps::
         bool IsPopupOpen(const char* str_id, ImGuiPopupFlags flags = 0)
     """
-    return cimgui.IsPopupOpen(_bytes(str), flags)
+    return cimgui.IsPopupOpen(_bytes(label), flags)
 
 def end_popup():
     """End a popup window.

--- a/imgui/core.pyx
+++ b/imgui/core.pyx
@@ -5803,7 +5803,7 @@ def table_setup_column(
         init_width_or_weight,
         user_id)
 
-def table_setup_scroll_freez(int cols, int rows):
+def table_setup_scroll_freeze(int cols, int rows):
     """
 
     .. wraps::


### PR DESCRIPTION
Was trying to do some more complex UIs and encountered a few bugs:
 - `table_setup_scroll_freez()` typo, should be `table_setup_scroll_freeze()`
 - `is_popup_open()` passes the `str` type instead of the `label` value to `_bytes()`, causing a crash
This of course is a simple fix to both.