### PR TITLE
Some fixes

### DIFF
--- a/imgui/cimgui.pxd
+++ b/imgui/cimgui.pxd
@@ -755,7 +755,7 @@ cdef extern from "imgui.h":
     ctypedef struct ImFontAtlas:  # ✓ 
         ImFontAtlasFlags    Flags # ✗
         void*               TexID  # ✓
-        int                 TexDesiredWidth # ✗
+        int                 TexDesiredWidth # ✓
         int                 TexGlyphPadding # ✗
         bool                Locked # ✗
         

--- a/imgui/core.pyx
+++ b/imgui/core.pyx
@@ -9446,7 +9446,7 @@ def is_item_deactivated():
     .. wraps:
         bool IsItemDeactivated()
     """
-    return cimgui.IsItemDeactivated
+    return cimgui.IsItemDeactivated()
 
 def is_item_deactivated_after_edit():
     """Was the last item just made inactive and made a value change when it was active? (e.g. Slider/Drag moved).

--- a/imgui/core.pyx
+++ b/imgui/core.pyx
@@ -2499,6 +2499,14 @@ cdef class _FontAtlas(object):
     def texture_height(self):
         return <int>self._ptr.TexHeight
 
+    @property
+    def texture_desired_width(self):
+        return <int>self._ptr.TexDesiredWidth
+
+    @texture_desired_width.setter
+    def texture_desired_width(self, int value):
+        self._ptr.TexDesiredWidth = value
+
 
     @texture_id.setter
     def texture_id(self, value):


### PR DESCRIPTION
- Now is_item_deactivated returns the actual value instead of the function callable
- Implemented io.fonts.texture_desired_width

The texture_desired_width can be essential when importing many and large fonts, because the default max of 4096 can run out quite quick and will easily cause GL_INVALID_VALUE errors when refreshing the font texture due to the ridiculous resulting texture height. I don't know why it isn't done by default (might be something to look into implementing in the integrations?), but I've found that now setting:
```py
io.fonts.texture_desired_width = gl.glGetIntegerv(gl.GL_MAX_TEXTURE_SIZE)
```
allows me to get the most out of what I can work with. In my case it was 8192, double the default 4096, and allowed me to scale my interface to 4x+ when without it only went up to 1.7x before crashing.