### PR TITLE
Fix: Auto-resizing input buffer

### DIFF
--- a/imgui/core.pyx
+++ b/imgui/core.pyx
@@ -2903,8 +2903,6 @@ cdef class _callback_user_info(object):
     
     cdef object callback_fn
     cdef user_data
-    cdef char* text_input_buffer
-    cdef int text_input_buffer_size
 
     def __init__(self):
         pass
@@ -3040,7 +3038,20 @@ cdef class _ImGuiInputTextCallbackData(object):
     def buffer(self):
         self._require_pointer()
         return _from_bytes(self._ptr.Buf)
-        
+    
+    @buffer.setter
+    def buffer(self, str buffer):
+        self._require_pointer()
+        _buffer = _bytes(buffer)
+        _buffer_length = len(_buffer)
+        if _buffer_length < self._ptr.BufSize:
+            # Note: When copying several characters at once, there is this
+            #       one frame where _ptr.BufSize is not yet updated (bug?).
+            #       thus we skip it here.
+            strncpy(self._ptr.Buf, _buffer, _buffer_length)
+            self._ptr.BufTextLen = _buffer_length
+            self._ptr.BufDirty = True
+
     @property
     def buffer_text_length(self):
         self._require_pointer()


### PR DESCRIPTION
This has been issued in #278.

The auto-resizing functionality of DearImgui uses a callback, and the user is responsible for managing the underlying buffer (malloc, realloc, free). Since in `pyimgui` the string buffer is internally managed, it wasn't possible to implement the functionality via python.

Now the resizing of the buffer, if asked via the `imgui.INPUT_TEXT_CALLBACK_RESIZE`, is done internally and is fully transparent to python users. If the user provides a custom callback, it is still called properly after the internal buffer resizing. 

Moreover, it is not very python friendly to ask for a buffer with a given size that is growable; one would have to create a variable `buffer_size`, globally access it in a provided callback function, and update it when the resize callback is called. This all comes from the c/c++ management of character strings and does not make a lot of sense for a python user. Thus I decided to simplify a bit the prototype of `input_text`, `input_text_multiline`, and `input_text_with_hint`. Now the argument `buffer_length` is optional and has a value of `-1` by default. In this case, the buffer size sent to DearImgui is the length of the argument `value` and the flag `imgui.INPUT_TEXT_CALLBACK_RESIZE` is automatically set.

This allows writing input text field as
```python
_, buf = imgui.input_text("Basic", buf)
_, buf = imgui.input_text_multiline("Multiline", buf)
_, buf = imgui.input_text_with_hint("With hint", "astuce", buf)
```
Of course, the old syntax with the `buffer_length` argument is still usable and would lead to a field with a maximum byte length
```python
_, buf = imgui.input_text("With max", buf, 32)
```

I consider this PR a work in progress since working on this has highlighted some weird and suboptimal functioning of `pyimgui` that I wish to fix. DearImgui asks for a `char*` that we must create from the passed `value` argument. Currently for each call of `input_text()`, memory is dynamically allocated with `malloc`, the content is copied from `value` to the internal buffer, and this buffer is passed to DearImgui. The internal buffer is freed at the end of the function. This is problematic since all of this is done for each text field and for each frame (which is a lot). I am considering implementing a memory pool internally to `pyimgui` that would be allocated at the start and using it instead of dynamically allocating memory for each `input_text()` call.

Moreover, there is some cleaning to do in the methods of the class `_ImGuiInputTextCallbackData`.

Any feedback is welcome :)