### PR TITLE
Change 'ini_file_name' and 'log_file_name' to accept str, bytes, or None

### DIFF
--- a/imgui/core.pyx
+++ b/imgui/core.pyx
@@ -2523,21 +2523,33 @@ cdef class _IO(object):
 
     @property
     def log_file_name(self):
-        return self._ptr.LogFilename
+        return _from_bytes(self._ptr.LogFilename)
 
     @log_file_name.setter
-    def log_file_name(self, char* value):
-        self._keep_logfile_alive = value
-        self._ptr.LogFilename = value
+    def log_file_name(self, value):
+        assert (value is None or isinstance(value, str) or isinstance(value, bytes)), "`log_file_name` must be a string or None"
+        value_bytes = None
+        if value is None: value_bytes = b''
+        elif isinstance(value, str): value_bytes = _bytes(value)
+        else: value_bytes = value
+
+        self._keep_logfile_alive = value_bytes
+        self._ptr.LogFilename = value_bytes
 
     @property
     def ini_file_name(self):
-        return self._ptr.IniFilename
+        return _from_bytes(self._ptr.IniFilename)
 
     @ini_file_name.setter
-    def ini_file_name(self, char* value):
-        self._keep_ini_alive = value
-        self._ptr.IniFilename = value
+    def ini_file_name(self, value):
+        assert (value is None or isinstance(value, str) or isinstance(value, bytes)), "`ini_file_name` must be a string or None"
+        value_bytes = None
+        if value is None: value_bytes = b''
+        elif isinstance(value, str): value_bytes = _bytes(value)
+        else: value_bytes = value
+
+        self._keep_ini_alive = value_bytes
+        self._ptr.IniFilename = value_bytes
 
     @property
     def mouse_double_click_time(self):


### PR DESCRIPTION
This has been issued in #290

For python users, it feels more natural to use strings to manage config and log filenames instead of `bytes`. I thus changed the interface of `ini_file_name` and  `log_file_name` to accept `str` and `None`. It is now possible to write:

```python
io = imgui.get_io()
io.ini_file_name = "other_name.ini"
io.ini_file_name = None
io.ini_file_name = ""
```

I kept the option of passing a `bytes` for backward compatibilities; this still works:
```python
io = imgui.get_io()
io.ini_file_name = b'other_name.ini'
```

I also changed the return type of the getter to be an `str` instead of a `bytes`. This is unfortunately not backward compatible but feels more python friendly, and I don't think this is a feature that was intensively used.