### PR TITLE
Fix compilation on MinGW Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import os
 import sys
+import sysconfig
 from itertools import chain
 
 from setuptools import setup, Extension, find_packages
@@ -43,13 +44,13 @@ VERSION = get_version(eval(version_line.split('=')[-1]))
 README = os.path.join(os.path.dirname(__file__), 'README.md')
 
 
-if sys.platform in ('cygwin', 'win32'):  # windows
+if sys.platform in ('cygwin', 'win32') and not sysconfig.get_platform().startswith('mingw'):  # Windows if not under MinGW
     # note: `/FI` means forced include in VC++/VC
     # note: may be obsoleted in future if ImGui gets patched
     os_specific_flags = ['/FIpy_imconfig.h']
     # placeholder for future
     os_specific_macros = []
-else:  # OS X and Linux
+else:  # OS X, Linux and Windows under MinGW (uses gcc)
     # note: `-include` means forced include in GCC/clang
     # note: may be obsoleted in future if ImGui gets patched
     # placeholder for future

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ if sys.platform in ('cygwin', 'win32') and not sysconfig.get_platform().startswi
     # note: `/FI` means forced include in VC++/VC
     # note: may be obsoleted in future if ImGui gets patched
     os_specific_flags = ['/FIpy_imconfig.h']
+    os_specific_libraries = []
     # placeholder for future
     os_specific_macros = []
 else:  # OS X, Linux and Windows under MinGW (uses gcc)
@@ -55,6 +56,10 @@ else:  # OS X, Linux and Windows under MinGW (uses gcc)
     # note: may be obsoleted in future if ImGui gets patched
     # placeholder for future
     os_specific_flags = ['-includeconfig-cpp/py_imconfig.h']
+    if sysconfig.get_platform().startswith('mingw'):
+        os_specific_libraries = ["imm32"]
+    else:
+        os_specific_libraries = []
     os_specific_macros = []
 
 
@@ -122,6 +127,7 @@ EXTENSIONS = [
     Extension(
         "imgui.core", extension_sources("imgui/core"),
         extra_compile_args=os_specific_flags,
+        libraries=os_specific_libraries,
         define_macros=[
             # note: for raising custom exceptions directly in ImGui code
             ('PYIMGUI_CUSTOM_EXCEPTION', None)
@@ -131,6 +137,7 @@ EXTENSIONS = [
     Extension(
         "imgui.internal", extension_sources("imgui/internal"),
         extra_compile_args=os_specific_flags,
+        libraries=os_specific_libraries,
         define_macros=[
             # note: for raising custom exceptions directly in ImGui code
             ('PYIMGUI_CUSTOM_EXCEPTION', None)


### PR DESCRIPTION
Fixes the incorrect compiler flags passed to gcc when compiling under MinGW in Windows as outlined in #301.

As also mentioned in the issue, I still haven't managed to get it to compile fully, the error I'm stuck on now is the following:
```
  g++ -shared -Wl,--enable-auto-image-base -pipe -pipe -s C:/Users/willyjl/AppData/Local/Temp/tmpc2_x8ydx.build-temp/config-cpp/py_imconfig.o C:/Users/willyjl/AppData/Local/Temp/tmpc2_x8ydx.build-temp/imgui-cpp/imgui.o C:/Users/willyjl/AppData/Local/Temp/tmpc2_x8ydx.build-temp/imgui-cpp/imgui_demo.o C:/Users/willyjl/AppData/Local/Temp/tmpc2_x8ydx.build-temp/imgui-cpp/imgui_draw.o C:/Users/willyjl/AppData/Local/Temp/tmpc2_x8ydx.build-temp/imgui-cpp/imgui_tables.o C:/Users/willyjl/AppData/Local/Temp/tmpc2_x8ydx.build-temp/imgui-cpp/imgui_widgets.o C:/Users/willyjl/AppData/Local/Temp/tmpc2_x8ydx.build-temp/imgui/core.o C:/Users/willyjl/AppData/Local/Temp/tmpc2_x8ydx.build-temp/config-cpp/core.cp310-mingw_x86_64.def -LC:/Users/willyjl/scoop/apps/msys2/2022-09-04/mingw64/lib/python3.10/config-3.10 -LC:/Users/willyjl/scoop/apps/msys2/2022-09-04/mingw64/lib -lpython3.10 -lm -lversion -lshlwapi -o C:/Users/willyjl/AppData/Local/Temp/tmp9sg2wl00.build-lib/imgui/core.cp310-mingw_x86_64.pyd
  C:/Users/willyjl/scoop/apps/msys2/2022-09-04/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/12.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: C:/Users/willyjl/AppData/Local/Temp/tmpc2_x8ydx.build-temp/imgui-cpp/imgui.o: in function `ImeSetInputScreenPosFn_DefaultImpl':
  C:\Users\willyjl\Desktop\Coding\pyimgui/imgui-cpp/imgui.cpp:10705: undefined reference to `ImmGetContext'
  C:/Users/willyjl/scoop/apps/msys2/2022-09-04/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/12.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: C:\Users\willyjl\Desktop\Coding\pyimgui/imgui-cpp/imgui.cpp:10711: undefined reference to `ImmSetCompositionWindow'
  C:/Users/willyjl/scoop/apps/msys2/2022-09-04/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/12.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: C:\Users\willyjl\Desktop\Coding\pyimgui/imgui-cpp/imgui.cpp:10712: undefined reference to `ImmReleaseContext'
  collect2.exe: error: ld returned 1 exit status
  ```

I'd like to get it to fully compile with this PR, so I set it as a draft for now.

But I'm lost on that error above, any help is welcome :D