### PR TITLE
Cleaned up doc/examples

### DIFF
--- a/doc/examples/fonts.py
+++ b/doc/examples/fonts.py
@@ -1,19 +1,20 @@
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
+
+from glob import glob
+from imgui.integrations.glfw import GlfwRenderer
+import OpenGL.GL as gl
+import glfw
+import imgui
 import os
 import random
-from glob import glob
-
-import glfw
-import OpenGL.GL as gl
-import imgui
-from imgui.integrations.glfw import GlfwRenderer
+import sys
 
 
 # use fonts bundled with imgui core project repository
 FONTS_DIR = glob(
     os.path.join(
-        os.path.dirname(__file__),
-        '..', '..', 'imgui-cpp', 'misc', 'fonts', "*.ttf"
+        os.path.dirname(__file__), "..", "..", "imgui-cpp", "misc", "fonts", "*.ttf"
     )
 )
 
@@ -41,14 +42,14 @@ def main():
     io.fonts.clear()
 
     # set global font scaling
-    io.font_global_scale = 1. / font_scaling_factor
+    io.font_global_scale = 1.0 / font_scaling_factor
 
     # dictionary of font objects from our font directory
     fonts = {
         os.path.split(font_path)[-1]: io.fonts.add_font_from_file_ttf(
             font_path,
             FONT_SIZE_IN_PIXELS * font_scaling_factor,
-            io.fonts.get_glyph_ranges_latin()
+            io.fonts.get_glyph_ranges_latin(),
         )
         for font_path in FONTS_DIR
     }
@@ -80,7 +81,7 @@ def main():
             imgui.text("This window uses same custom font for all widgets")
             imgui.end()
 
-        gl.glClearColor(1., 1., 1., 1)
+        gl.glClearColor(1.0, 1.0, 1.0, 1)
         gl.glClear(gl.GL_COLOR_BUFFER_BIT)
 
         imgui.render()
@@ -97,7 +98,7 @@ def impl_glfw_init():
 
     if not glfw.init():
         print("Could not initialize OpenGL context")
-        exit(1)
+        sys.exit(1)
 
     # OS X supports only forward-compatible core profiles from 3.2
     glfw.window_hint(glfw.CONTEXT_VERSION_MAJOR, 3)
@@ -107,15 +108,13 @@ def impl_glfw_init():
     glfw.window_hint(glfw.OPENGL_FORWARD_COMPAT, gl.GL_TRUE)
 
     # Create a windowed mode window and its OpenGL context
-    window = glfw.create_window(
-        int(width), int(height), window_name, None, None
-    )
+    window = glfw.create_window(int(width), int(height), window_name, None, None)
     glfw.make_context_current(window)
 
     if not window:
         glfw.terminate()
         print("Could not initialize Window")
-        exit(1)
+        sys.exit(1)
 
     return window
 

--- a/doc/examples/integrations_all_in_one.py
+++ b/doc/examples/integrations_all_in_one.py
@@ -2,8 +2,11 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import absolute_import
-
+import OpenGL.GL as gl
+import imgui
 import sys
+
+
 backend = "pygame"
 if "sdl2" in sys.argv:
     backend = "sdl2"
@@ -30,9 +33,6 @@ elif backend == "cocos2d":
     from cocos.director import director
     from imgui.integrations.cocos2d import ImguiLayer
 
-import OpenGL.GL as gl
-import imgui
-
 
 def main_sdl2():
     def pysdl2_init():
@@ -40,35 +40,42 @@ def main_sdl2():
         window_name = "minimal ImGui/SDL2 example"
         if SDL_Init(SDL_INIT_EVERYTHING) < 0:
             print("Error: SDL could not initialize! SDL Error: " + SDL_GetError())
-            exit(1)
+            sys.exit(1)
         SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1)
         SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 24)
         SDL_GL_SetAttribute(SDL_GL_STENCIL_SIZE, 8)
         SDL_GL_SetAttribute(SDL_GL_ACCELERATED_VISUAL, 1)
         SDL_GL_SetAttribute(SDL_GL_MULTISAMPLEBUFFERS, 1)
         SDL_GL_SetAttribute(SDL_GL_MULTISAMPLESAMPLES, 8)
-        SDL_GL_SetAttribute(SDL_GL_CONTEXT_FLAGS, SDL_GL_CONTEXT_FORWARD_COMPATIBLE_FLAG)
+        SDL_GL_SetAttribute(
+            SDL_GL_CONTEXT_FLAGS, SDL_GL_CONTEXT_FORWARD_COMPATIBLE_FLAG
+        )
         SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 4)
         SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 1)
         SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE)
         SDL_SetHint(SDL_HINT_MAC_CTRL_CLICK_EMULATE_RIGHT_CLICK, b"1")
         SDL_SetHint(SDL_HINT_VIDEO_HIGHDPI_DISABLED, b"1")
-        window = SDL_CreateWindow(window_name.encode('utf-8'),
-                                SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED,
-                                width, height,
-                                SDL_WINDOW_OPENGL|SDL_WINDOW_RESIZABLE)
+        window = SDL_CreateWindow(
+            window_name.encode("utf-8"),
+            SDL_WINDOWPOS_CENTERED,
+            SDL_WINDOWPOS_CENTERED,
+            width,
+            height,
+            SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE,
+        )
         if window is None:
             print("Error: Window could not be created! SDL Error: " + SDL_GetError())
-            exit(1)
+            sys.exit(1)
         gl_context = SDL_GL_CreateContext(window)
         if gl_context is None:
             print("Error: Cannot create OpenGL Context! SDL Error: " + SDL_GetError())
-            exit(1)
+            sys.exit(1)
         SDL_GL_MakeCurrent(window, gl_context)
         if SDL_GL_SetSwapInterval(1) < 0:
             print("Warning: Unable to set VSync! SDL Error: " + SDL_GetError())
-            exit(1)
+            sys.exit(1)
         return window, gl_context
+
     window, gl_context = pysdl2_init()
     renderer = SDL2Renderer(window)
     running = True
@@ -82,7 +89,7 @@ def main_sdl2():
         renderer.process_inputs()
         imgui.new_frame()
         on_frame()
-        gl.glClearColor(1., 1., 1., 1)
+        gl.glClearColor(1.0, 1.0, 1.0, 1)
         gl.glClear(gl.GL_COLOR_BUFFER_BIT)
         imgui.render()
         SDL_GL_SwapWindow(window)
@@ -96,33 +103,33 @@ def main_pygame():
     pygame.init()
     size = 800, 600
     pygame.display.set_mode(size, pygame.DOUBLEBUF | pygame.OPENGL | pygame.RESIZABLE)
-    
+
     imgui.create_context()
     impl = PygameRenderer()
-    
+
     io = imgui.get_io()
     io.fonts.add_font_default()
     io.display_size = size
-    
+
     show_custom_window = True
-    
+
     while 1:
         for event in pygame.event.get():
             if event.type == pygame.QUIT:
-                sys.exit()
+                sys.exit(0)
             impl.process_event(event)
         impl.process_inputs()
         imgui.new_frame()
-        
+
         if imgui.begin_main_menu_bar():
             if imgui.begin_menu("File", True):
 
                 clicked_quit, selected_quit = imgui.menu_item(
-                    "Quit", 'Cmd+Q', False, True
+                    "Quit", "Cmd+Q", False, True
                 )
 
                 if clicked_quit:
-                    exit(1)
+                    sys.exit(0)
 
                 imgui.end_menu()
             imgui.end_main_menu_bar()
@@ -133,9 +140,9 @@ def main_pygame():
             is_expand, show_custom_window = imgui.begin("Custom window", True)
             if is_expand:
                 imgui.text("Bar")
-                imgui.text_colored("Eggs", 0.2, 1., 0.)
+                imgui.text_colored("Eggs", 0.2, 1.0, 0.0)
             imgui.end()
-        
+
         # note: cannot use screen.fill((1, 1, 1)) because pygame's screen
         #       does not support fill() on OpenGL sufraces
         gl.glClearColor(1, 1, 1, 1)
@@ -151,22 +158,21 @@ def main_glfw():
         window_name = "minimal ImGui/GLFW3 example"
         if not glfw.init():
             print("Could not initialize OpenGL context")
-            exit(1)
+            sys.exit(1)
         # OS X supports only forward-compatible core profiles from 3.2
         glfw.window_hint(glfw.CONTEXT_VERSION_MAJOR, 3)
         glfw.window_hint(glfw.CONTEXT_VERSION_MINOR, 3)
         glfw.window_hint(glfw.OPENGL_PROFILE, glfw.OPENGL_CORE_PROFILE)
         glfw.window_hint(glfw.OPENGL_FORWARD_COMPAT, gl.GL_TRUE)
         # Create a windowed mode window and its OpenGL context
-        window = glfw.create_window(
-            int(width), int(height), window_name, None, None
-        )
+        window = glfw.create_window(int(width), int(height), window_name, None, None)
         glfw.make_context_current(window)
         if not window:
             glfw.terminate()
             print("Could not initialize Window")
-            exit(1)
+            sys.exit(1)
         return window
+
     window = glfw_init()
     impl = GlfwRenderer(window)
     while not glfw.window_should_close(window):
@@ -174,7 +180,7 @@ def main_glfw():
         impl.process_inputs()
         imgui.new_frame()
         on_frame()
-        gl.glClearColor(1., 1., 1., 1)
+        gl.glClearColor(1.0, 1.0, 1.0, 1)
         gl.glClear(gl.GL_COLOR_BUFFER_BIT)
         imgui.render()
         impl.render(imgui.get_draw_data())
@@ -195,7 +201,7 @@ def main_cocos2d():
             self.process_inputs()
             imgui.new_frame()
             on_frame()
-            gl.glClearColor(1., 1., 1., 1)
+            gl.glClearColor(1.0, 1.0, 1.0, 1)
             gl.glClear(gl.GL_COLOR_BUFFER_BIT)
             imgui.render()
 
@@ -209,17 +215,15 @@ def main_cocos2d():
 def on_frame():
     if imgui.begin_main_menu_bar():
         if imgui.begin_menu("File", True):
-            clicked_quit, selected_quit = imgui.menu_item(
-                "Quit", 'Cmd+Q', False, True
-            )
+            clicked_quit, selected_quit = imgui.menu_item("Quit", "Cmd+Q", False, True)
             if clicked_quit:
-                exit(1)
+                sys.exit(0)
             imgui.end_menu()
         imgui.end_main_menu_bar()
     imgui.show_test_window()
     imgui.begin("Custom window", True)
     imgui.text("Bar")
-    imgui.text_colored("Eggs", 0.2, 1., 0.)
+    imgui.text_colored("Eggs", 0.2, 1.0, 0.0)
     imgui.end()
 
 

--- a/doc/examples/integrations_cocos2d.py
+++ b/doc/examples/integrations_cocos2d.py
@@ -1,12 +1,13 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
 from __future__ import absolute_import
-
-import cocos
 from cocos.director import director
-
-from pyglet import gl
-
 from imgui.integrations.cocos2d import ImguiLayer
+from pyglet import gl
+import cocos
 import imgui
+import sys
 
 
 class HelloWorld(ImguiLayer):
@@ -25,11 +26,11 @@ class HelloWorld(ImguiLayer):
             if imgui.begin_menu("File", True):
 
                 clicked_quit, selected_quit = imgui.menu_item(
-                    "Quit", 'Cmd+Q', False, True
+                    "Quit", "Cmd+Q", False, True
                 )
 
                 if clicked_quit:
-                    exit(1)
+                    sys.exit()
 
                 imgui.end_menu()
             imgui.end_main_menu_bar()
@@ -40,10 +41,10 @@ class HelloWorld(ImguiLayer):
             is_expand, self.show_custom_window = imgui.begin("Custom window", True)
             if is_expand:
                 imgui.text("Bar")
-                imgui.text_colored("Eggs", 0.2, 1., 0.)
+                imgui.text_colored("Eggs", 0.2, 1.0, 0.0)
             imgui.end()
 
-        gl.glClearColor(1., 1., 1., 1)
+        gl.glClearColor(1.0, 1.0, 1.0, 1)
         gl.glClear(gl.GL_COLOR_BUFFER_BIT)
 
         imgui.render()

--- a/doc/examples/integrations_glfw3.py
+++ b/doc/examples/integrations_glfw3.py
@@ -1,18 +1,21 @@
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-import glfw
-import OpenGL.GL as gl
 
-import imgui
 from imgui.integrations.glfw import GlfwRenderer
 from testwindow import show_test_window
+import OpenGL.GL as gl
+import glfw
+import imgui
+import sys
+
 
 def main():
     imgui.create_context()
     window = impl_glfw_init()
     impl = GlfwRenderer(window)
-    
+
     show_custom_window = True
-    
+
     while not glfw.window_should_close(window):
         glfw.poll_events()
         impl.process_inputs()
@@ -23,29 +26,28 @@ def main():
             if imgui.begin_menu("File", True):
 
                 clicked_quit, selected_quit = imgui.menu_item(
-                    "Quit", 'Cmd+Q', False, True
+                    "Quit", "Cmd+Q", False, True
                 )
 
                 if clicked_quit:
-                    exit(1)
+                    sys.exit(0)
 
                 imgui.end_menu()
             imgui.end_main_menu_bar()
-
 
         if show_custom_window:
             is_expand, show_custom_window = imgui.begin("Custom window", True)
             if is_expand:
                 imgui.text("Bar")
                 imgui.text_ansi("B\033[31marA\033[mnsi ")
-                imgui.text_ansi_colored("Eg\033[31mgAn\033[msi ", 0.2, 1., 0.)
-                imgui.extra.text_ansi_colored("Eggs", 0.2, 1., 0.)
+                imgui.text_ansi_colored("Eg\033[31mgAn\033[msi ", 0.2, 1.0, 0.0)
+                imgui.extra.text_ansi_colored("Eggs", 0.2, 1.0, 0.0)
             imgui.end()
 
         show_test_window()
-        #imgui.show_test_window()
+        # imgui.show_test_window()
 
-        gl.glClearColor(1., 1., 1., 1)
+        gl.glClearColor(1.0, 1.0, 1.0, 1)
         gl.glClear(gl.GL_COLOR_BUFFER_BIT)
 
         imgui.render()
@@ -62,7 +64,7 @@ def impl_glfw_init():
 
     if not glfw.init():
         print("Could not initialize OpenGL context")
-        exit(1)
+        sys.exit(1)
 
     # OS X supports only forward-compatible core profiles from 3.2
     glfw.window_hint(glfw.CONTEXT_VERSION_MAJOR, 3)
@@ -72,15 +74,13 @@ def impl_glfw_init():
     glfw.window_hint(glfw.OPENGL_FORWARD_COMPAT, gl.GL_TRUE)
 
     # Create a windowed mode window and its OpenGL context
-    window = glfw.create_window(
-        int(width), int(height), window_name, None, None
-    )
+    window = glfw.create_window(int(width), int(height), window_name, None, None)
     glfw.make_context_current(window)
 
     if not window:
         glfw.terminate()
         print("Could not initialize Window")
-        exit(1)
+        sys.exit(1)
 
     return window
 

--- a/doc/examples/integrations_pygame.py
+++ b/doc/examples/integrations_pygame.py
@@ -1,12 +1,12 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
 from __future__ import absolute_import
-
-import sys
-
-import pygame
-import OpenGL.GL as gl
-
 from imgui.integrations.pygame import PygameRenderer
+import OpenGL.GL as gl
 import imgui
+import pygame
+import sys
 
 
 def main():
@@ -20,13 +20,13 @@ def main():
 
     io = imgui.get_io()
     io.display_size = size
-    
+
     show_custom_window = True
 
     while 1:
         for event in pygame.event.get():
             if event.type == pygame.QUIT:
-                sys.exit()
+                sys.exit(0)
             impl.process_event(event)
         impl.process_inputs()
 
@@ -36,11 +36,11 @@ def main():
             if imgui.begin_menu("File", True):
 
                 clicked_quit, selected_quit = imgui.menu_item(
-                    "Quit", 'Cmd+Q', False, True
+                    "Quit", "Cmd+Q", False, True
                 )
 
                 if clicked_quit:
-                    exit(1)
+                    sys.exit(0)
 
                 imgui.end_menu()
             imgui.end_main_menu_bar()
@@ -51,7 +51,7 @@ def main():
             is_expand, show_custom_window = imgui.begin("Custom window", True)
             if is_expand:
                 imgui.text("Bar")
-                imgui.text_colored("Eggs", 0.2, 1., 0.)
+                imgui.text_colored("Eggs", 0.2, 1.0, 0.0)
             imgui.end()
 
         # note: cannot use screen.fill((1, 1, 1)) because pygame's screen

--- a/doc/examples/integrations_pyglet.py
+++ b/doc/examples/integrations_pyglet.py
@@ -1,26 +1,30 @@
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
-import pyglet
+from __future__ import absolute_import
 from pyglet import gl
 from testwindow import show_test_window
-
+import pyglet
 import imgui
+import sys
+
+
 # Note that we could explicitly choose to use PygletFixedPipelineRenderer
 # or PygletProgrammablePipelineRenderer, but create_renderer handles the
 # version checking for us.
 from imgui.integrations.pyglet import create_renderer
-    
+
+
 def main():
 
     window = pyglet.window.Window(width=1280, height=720, resizable=True)
     gl.glClearColor(1, 1, 1, 1)
     imgui.create_context()
     impl = create_renderer(window)
-    
+
     global show_custom_window
     show_custom_window = True
-    
+
     def update(dt):
         impl.process_inputs()
         imgui.new_frame()
@@ -28,27 +32,27 @@ def main():
             if imgui.begin_menu("File", True):
 
                 clicked_quit, selected_quit = imgui.menu_item(
-                    "Quit", 'Cmd+Q', False, True
+                    "Quit", "Cmd+Q", False, True
                 )
 
                 if clicked_quit:
-                    exit(1)
+                    sys.exit(0)
 
                 imgui.end_menu()
             imgui.end_main_menu_bar()
 
         show_test_window()
-        #imgui.show_test_window()
+        # imgui.show_test_window()
 
         global show_custom_window
         if show_custom_window:
             is_expand, show_custom_window = imgui.begin("Custom window", True)
             if is_expand:
                 imgui.text("Bar")
-                imgui.text_colored("Eggs", 0.2, 1., 0.)
+                imgui.text_colored("Eggs", 0.2, 1.0, 0.0)
 
                 imgui.text_ansi("B\033[31marA\033[mnsi ")
-                imgui.text_ansi_colored("Eg\033[31mgAn\033[msi ", 0.2, 1., 0.)
+                imgui.text_ansi_colored("Eg\033[31mgAn\033[msi ", 0.2, 1.0, 0.0)
 
             imgui.end()
 
@@ -58,7 +62,7 @@ def main():
         imgui.render()
         impl.render(imgui.get_draw_data())
 
-    pyglet.clock.schedule_interval(draw, 1/120.)
+    pyglet.clock.schedule_interval(draw, 1 / 120.0)
     pyglet.app.run()
     impl.shutdown()
 

--- a/doc/examples/integrations_pysdl2.py
+++ b/doc/examples/integrations_pysdl2.py
@@ -1,11 +1,13 @@
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from sdl2 import *
-import ctypes
-import OpenGL.GL as gl
 
-import imgui
 from imgui.integrations.sdl2 import SDL2Renderer
 from testwindow import show_test_window
+from sdl2 import *
+import OpenGL.GL as gl
+import ctypes
+import imgui
+import sys
 
 
 def main():
@@ -31,26 +33,26 @@ def main():
             if imgui.begin_menu("File", True):
 
                 clicked_quit, selected_quit = imgui.menu_item(
-                    "Quit", 'Cmd+Q', False, True
+                    "Quit", "Cmd+Q", False, True
                 )
 
                 if clicked_quit:
-                    exit(1)
+                    sys.exit(0)
 
                 imgui.end_menu()
             imgui.end_main_menu_bar()
 
         show_test_window()
-        #imgui.show_test_window()
+        # imgui.show_test_window()
 
         if show_custom_window:
             is_expand, show_custom_window = imgui.begin("Custom window", True)
             if is_expand:
                 imgui.text("Bars")
-                imgui.text_colored("Eggs", 0.2, 1., 0.)
+                imgui.text_colored("Eggs", 0.2, 1.0, 0.0)
             imgui.end()
 
-        gl.glClearColor(1., 1., 1., 1)
+        gl.glClearColor(1.0, 1.0, 1.0, 1)
         gl.glClear(gl.GL_COLOR_BUFFER_BIT)
 
         imgui.render()
@@ -68,8 +70,11 @@ def impl_pysdl2_init():
     window_name = "minimal ImGui/SDL2 example"
 
     if SDL_Init(SDL_INIT_EVERYTHING) < 0:
-        print("Error: SDL could not initialize! SDL Error: " + SDL_GetError().decode("utf-8"))
-        exit(1)
+        print(
+            "Error: SDL could not initialize! SDL Error: "
+            + SDL_GetError().decode("utf-8")
+        )
+        sys.exit(1)
 
     SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1)
     SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 24)
@@ -85,24 +90,36 @@ def impl_pysdl2_init():
     SDL_SetHint(SDL_HINT_MAC_CTRL_CLICK_EMULATE_RIGHT_CLICK, b"1")
     SDL_SetHint(SDL_HINT_VIDEO_HIGHDPI_DISABLED, b"1")
 
-    window = SDL_CreateWindow(window_name.encode('utf-8'),
-                              SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED,
-                              width, height,
-                              SDL_WINDOW_OPENGL|SDL_WINDOW_RESIZABLE)
+    window = SDL_CreateWindow(
+        window_name.encode("utf-8"),
+        SDL_WINDOWPOS_CENTERED,
+        SDL_WINDOWPOS_CENTERED,
+        width,
+        height,
+        SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE,
+    )
 
     if window is None:
-        print("Error: Window could not be created! SDL Error: " + SDL_GetError().decode("utf-8"))
-        exit(1)
+        print(
+            "Error: Window could not be created! SDL Error: "
+            + SDL_GetError().decode("utf-8")
+        )
+        sys.exit(1)
 
     gl_context = SDL_GL_CreateContext(window)
     if gl_context is None:
-        print("Error: Cannot create OpenGL Context! SDL Error: " + SDL_GetError().decode("utf-8"))
-        exit(1)
+        print(
+            "Error: Cannot create OpenGL Context! SDL Error: "
+            + SDL_GetError().decode("utf-8")
+        )
+        sys.exit(1)
 
     SDL_GL_MakeCurrent(window, gl_context)
     if SDL_GL_SetSwapInterval(1) < 0:
-        print("Warning: Unable to set VSync! SDL Error: " + SDL_GetError().decode("utf-8"))
-        exit(1)
+        print(
+            "Warning: Unable to set VSync! SDL Error: " + SDL_GetError().decode("utf-8")
+        )
+        sys.exit(1)
 
     return window, gl_context
 

--- a/doc/examples/plots.py
+++ b/doc/examples/plots.py
@@ -1,15 +1,18 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
 from array import array
+from imgui.integrations.glfw import GlfwRenderer
 from math import sin, pi
 from random import random
-
-import glfw
-import OpenGL.GL as gl
-import imgui
-from imgui.integrations.glfw import GlfwRenderer
 from time import time
+import OpenGL.GL as gl
+import glfw
+import imgui
+import sys
 
 
-C = .01
+C = 0.01
 L = int(pi * 2 * 100)
 
 
@@ -18,8 +21,8 @@ def main():
     imgui.create_context()
     impl = GlfwRenderer(window)
 
-    plot_values = array('f', [sin(x * C) for x in range(L)])
-    histogram_values = array('f', [random() for _ in range(20)])
+    plot_values = array("f", [sin(x * C) for x in range(L)])
+    histogram_values = array("f", [random() for _ in range(20)])
 
     while not glfw.window_should_close(window):
         glfw.poll_events()
@@ -48,10 +51,9 @@ def main():
             graph_size=(0, 50),
         )
 
-
         imgui.end()
 
-        gl.glClearColor(1., 1., 1., 1)
+        gl.glClearColor(1.0, 1.0, 1.0, 1)
         gl.glClear(gl.GL_COLOR_BUFFER_BIT)
 
         imgui.render()
@@ -68,7 +70,7 @@ def impl_glfw_init():
 
     if not glfw.init():
         print("Could not initialize OpenGL context")
-        exit(1)
+        sys.exit(1)
 
     # OS X supports only forward-compatible core profiles from 3.2
     glfw.window_hint(glfw.CONTEXT_VERSION_MAJOR, 3)
@@ -78,15 +80,13 @@ def impl_glfw_init():
     glfw.window_hint(glfw.OPENGL_FORWARD_COMPAT, gl.GL_TRUE)
 
     # Create a windowed mode window and its OpenGL context
-    window = glfw.create_window(
-        int(width), int(height), window_name, None, None
-    )
+    window = glfw.create_window(int(width), int(height), window_name, None, None)
     glfw.make_context_current(window)
 
     if not window:
         glfw.terminate()
         print("Could not initialize Window")
-        exit(1)
+        sys.exit(1)
 
     return window
 

--- a/doc/examples/testwindow.py
+++ b/doc/examples/testwindow.py
@@ -1,11 +1,13 @@
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-import imgui
-import sys
-import math
-import os
-import itertools
+
 from array import array
 import colorsys
+import imgui
+import itertools
+import math
+import os
+import sys
 
 # Examples Apps (accessible from the "Examples" menu)
 show_app_main_menu_bar = False
@@ -228,7 +230,8 @@ borders_v_borders = True
 
 collapsing_headers_closable_group = True
 
-filtering_filter = None # Todo - bind this in cimgui.pxd
+filtering_filter = None  # Todo - bind this in cimgui.pxd
+
 
 def show_help_marker(desc):
 
@@ -574,7 +577,7 @@ def show_test_window():
     if not imgui.begin(label="ImGui Demo", closable=no_close, flags=window_flags):
         # Early out if the window is collapsed, as an optimization.
         imgui.end()
-        sys.exit(1)
+        sys.exit(0)
 
     imgui.text("dear imgui says hello. (" + str(imgui.get_version()) + ")")
 
@@ -715,7 +718,7 @@ def show_test_window():
                     imgui.same_line()
                     imgui.text("<<PRESS SPACE TO DISABLE>>")
                 if imgui.is_key_pressed(imgui.get_key_index(imgui.KEY_SPACE)):
-                    io.config_flags &= ~ imgui.CONFIG_NO_MOUSE
+                    io.config_flags &= ~imgui.CONFIG_NO_MOUSE
                 #     clicked, io.config_flags = imgui.checkbox_flags("io.ConfigFlags: NoMouseCursorChange", io.config_flags, imgui.CONFIG_NO_MOUSE_CURSOR_CHANGE)
 
             imgui.same_line()
@@ -1699,9 +1702,7 @@ def show_test_window():
             )
 
             misc_flags = (
-                (imgui.COLOR_EDIT_HDR
-                if color_picker_hdr
-                else 0)
+                (imgui.COLOR_EDIT_HDR if color_picker_hdr else 0)
                 | (0 if color_picker_drag_and_drop else imgui.COLOR_EDIT_NO_DRAG_DROP)
                 | (
                     imgui.COLOR_EDIT_ALPHA_PREVIEW_HALF
@@ -1728,10 +1729,14 @@ def show_test_window():
             )
 
             imgui.text("Color widget HSV with Alpha:")
-            changed, color_picker_color = imgui.color_edit4("MyColor##2", *color_picker_color, imgui.COLOR_EDIT_HSV  | misc_flags)
+            changed, color_picker_color = imgui.color_edit4(
+                "MyColor##2", *color_picker_color, imgui.COLOR_EDIT_HSV | misc_flags
+            )
 
-            imgui.text("Color widget with Float Display:");
-            changed, color_picker_color = imgui.color_edit4("MyColor##2f", *color_picker_color, imgui.COLOR_EDIT_FLOAT | misc_flags)
+            imgui.text("Color widget with Float Display:")
+            changed, color_picker_color = imgui.color_edit4(
+                "MyColor##2f", *color_picker_color, imgui.COLOR_EDIT_FLOAT | misc_flags
+            )
 
             # imgui.text("Color button with Picker:");
             # imgui.same_line();
@@ -3281,7 +3286,9 @@ def show_test_window():
         imgui.text("WantCaptureKeyboard: " + str(io.want_capture_keyboard))
         imgui.text("WantTextInput: " + str(io.want_text_input))
         imgui.text("WantSetMousePos: " + str(io.want_set_mouse_pos))
-        imgui.text("NavActive: " + str(io.nav_active) +  "NavVisible: " + str(io.nav_visible))
+        imgui.text(
+            "NavActive: " + str(io.nav_active) + "NavVisible: " + str(io.nav_visible)
+        )
 
         #     if imgui.tree_node("Keyboard, Mouse & Navigation State"):
         #     {


### PR DESCRIPTION
Added shebang to all examples.
Added encoding string for all examples.
Standardized import order for a cleaner look.
Changed all exits to `sys.exit` as `exit` is not guaranteed.
Changed all exits to use the proper exit code (1 for error, 0 for no error).
Ran black over examples to clean up a lot of PEP8 errors and standardize formatting.