### PR TITLE
opengl integration: fix alpha blending bug on Wayland

### DIFF
--- a/imgui/integrations/opengl.py
+++ b/imgui/integrations/opengl.py
@@ -155,7 +155,7 @@ class ProgrammablePipelineRenderer(BaseOpenGLRenderer):
 
         gl.glEnable(gl.GL_BLEND)
         gl.glBlendEquation(gl.GL_FUNC_ADD)
-        gl.glBlendFunc(gl.GL_SRC_ALPHA, gl.GL_ONE_MINUS_SRC_ALPHA)
+        gl.glBlendFuncSeparate(gl.GL_SRC_ALPHA, gl.GL_ONE_MINUS_SRC_ALPHA, gl.GL_ONE, gl.GL_ONE_MINUS_SRC_ALPHA)
         gl.glDisable(gl.GL_CULL_FACE)
         gl.glDisable(gl.GL_DEPTH_TEST)
         gl.glEnable(gl.GL_SCISSOR_TEST)


### PR DESCRIPTION
on Wayland (at least that is where i've encountered this bug for the first time) currently implemented alpha blending causes strange ghost bugs in rendering.

The fix was taken from the [ same imgui's issue](https://github.com/ocornut/imgui/issues/3813#issuecomment-779067870)

