### PR TITLE
Changed library to require supported versions of Python

### DIFF
--- a/ci/completion.py
+++ b/ci/completion.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import subprocess
 import sys
 import re
@@ -48,7 +47,7 @@ def with_pxd(ctx, pxd_files):
     lines = []
     for pxd_file in pxd_files:
         lines += pxd_file.readlines()
-    
+
     all_count = len(list(filter(ALL_RE.match, lines)))
     done_count = len(list(filter(DONE_RE.match, lines)))
 

--- a/ci/dropbox_upload.py
+++ b/ci/dropbox_upload.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Script for uploading securely built distributions (artifacts) to private
 Dropbox directory.

--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 import sys
 from traceback import print_exc

--- a/doc/examples/fonts.py
+++ b/doc/examples/fonts.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
+#!/usr/bin/env python3
 
 from glob import glob
 from imgui.integrations.glfw import GlfwRenderer
@@ -14,7 +13,13 @@ import sys
 # use fonts bundled with imgui core project repository
 FONTS_DIR = glob(
     os.path.join(
-        os.path.dirname(__file__), "..", "..", "imgui-cpp", "misc", "fonts", "*.ttf"
+        os.path.dirname(__file__),
+        "..",
+        "..",
+        "imgui-cpp",
+        "misc",
+        "fonts",
+        "*.ttf",
     )
 )
 
@@ -108,7 +113,9 @@ def impl_glfw_init():
     glfw.window_hint(glfw.OPENGL_FORWARD_COMPAT, gl.GL_TRUE)
 
     # Create a windowed mode window and its OpenGL context
-    window = glfw.create_window(int(width), int(height), window_name, None, None)
+    window = glfw.create_window(
+        int(width), int(height), window_name, None, None
+    )
     glfw.make_context_current(window)
 
     if not window:

--- a/doc/examples/integrations_all_in_one.py
+++ b/doc/examples/integrations_all_in_one.py
@@ -1,7 +1,5 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
+#!/usr/bin/env python3
 
-from __future__ import absolute_import
 import OpenGL.GL as gl
 import imgui
 import sys
@@ -39,7 +37,9 @@ def main_sdl2():
         width, height = 1280, 720
         window_name = "minimal ImGui/SDL2 example"
         if SDL_Init(SDL_INIT_EVERYTHING) < 0:
-            print("Error: SDL could not initialize! SDL Error: " + SDL_GetError())
+            print(
+                "Error: SDL could not initialize! SDL Error: " + SDL_GetError()
+            )
             sys.exit(1)
         SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1)
         SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 24)
@@ -52,7 +52,9 @@ def main_sdl2():
         )
         SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 4)
         SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 1)
-        SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE)
+        SDL_GL_SetAttribute(
+            SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE
+        )
         SDL_SetHint(SDL_HINT_MAC_CTRL_CLICK_EMULATE_RIGHT_CLICK, b"1")
         SDL_SetHint(SDL_HINT_VIDEO_HIGHDPI_DISABLED, b"1")
         window = SDL_CreateWindow(
@@ -64,11 +66,17 @@ def main_sdl2():
             SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE,
         )
         if window is None:
-            print("Error: Window could not be created! SDL Error: " + SDL_GetError())
+            print(
+                "Error: Window could not be created! SDL Error: "
+                + SDL_GetError()
+            )
             sys.exit(1)
         gl_context = SDL_GL_CreateContext(window)
         if gl_context is None:
-            print("Error: Cannot create OpenGL Context! SDL Error: " + SDL_GetError())
+            print(
+                "Error: Cannot create OpenGL Context! SDL Error: "
+                + SDL_GetError()
+            )
             sys.exit(1)
         SDL_GL_MakeCurrent(window, gl_context)
         if SDL_GL_SetSwapInterval(1) < 0:
@@ -102,7 +110,9 @@ def main_sdl2():
 def main_pygame():
     pygame.init()
     size = 800, 600
-    pygame.display.set_mode(size, pygame.DOUBLEBUF | pygame.OPENGL | pygame.RESIZABLE)
+    pygame.display.set_mode(
+        size, pygame.DOUBLEBUF | pygame.OPENGL | pygame.RESIZABLE
+    )
 
     imgui.create_context()
     impl = PygameRenderer()
@@ -123,7 +133,6 @@ def main_pygame():
 
         if imgui.begin_main_menu_bar():
             if imgui.begin_menu("File", True):
-
                 clicked_quit, selected_quit = imgui.menu_item(
                     "Quit", "Cmd+Q", False, True
                 )
@@ -165,7 +174,9 @@ def main_glfw():
         glfw.window_hint(glfw.OPENGL_PROFILE, glfw.OPENGL_CORE_PROFILE)
         glfw.window_hint(glfw.OPENGL_FORWARD_COMPAT, gl.GL_TRUE)
         # Create a windowed mode window and its OpenGL context
-        window = glfw.create_window(int(width), int(height), window_name, None, None)
+        window = glfw.create_window(
+            int(width), int(height), window_name, None, None
+        )
         glfw.make_context_current(window)
         if not window:
             glfw.terminate()
@@ -215,7 +226,9 @@ def main_cocos2d():
 def on_frame():
     if imgui.begin_main_menu_bar():
         if imgui.begin_menu("File", True):
-            clicked_quit, selected_quit = imgui.menu_item("Quit", "Cmd+Q", False, True)
+            clicked_quit, selected_quit = imgui.menu_item(
+                "Quit", "Cmd+Q", False, True
+            )
             if clicked_quit:
                 sys.exit(0)
             imgui.end_menu()

--- a/doc/examples/integrations_cocos2d.py
+++ b/doc/examples/integrations_cocos2d.py
@@ -1,7 +1,5 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
+#!/usr/bin/env python3
 
-from __future__ import absolute_import
 from cocos.director import director
 from imgui.integrations.cocos2d import ImguiLayer
 from pyglet import gl
@@ -24,7 +22,6 @@ class HelloWorld(ImguiLayer):
 
         if imgui.begin_main_menu_bar():
             if imgui.begin_menu("File", True):
-
                 clicked_quit, selected_quit = imgui.menu_item(
                     "Quit", "Cmd+Q", False, True
                 )
@@ -38,7 +35,9 @@ class HelloWorld(ImguiLayer):
         imgui.show_test_window()
 
         if self.show_custom_window:
-            is_expand, self.show_custom_window = imgui.begin("Custom window", True)
+            is_expand, self.show_custom_window = imgui.begin(
+                "Custom window", True
+            )
             if is_expand:
                 imgui.text("Bar")
                 imgui.text_colored("Eggs", 0.2, 1.0, 0.0)

--- a/doc/examples/integrations_glfw3.py
+++ b/doc/examples/integrations_glfw3.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
+#!/usr/bin/env python3
 
 from imgui.integrations.glfw import GlfwRenderer
 from testwindow import show_test_window
@@ -24,7 +23,6 @@ def main():
 
         if imgui.begin_main_menu_bar():
             if imgui.begin_menu("File", True):
-
                 clicked_quit, selected_quit = imgui.menu_item(
                     "Quit", "Cmd+Q", False, True
                 )
@@ -40,7 +38,9 @@ def main():
             if is_expand:
                 imgui.text("Bar")
                 imgui.text_ansi("B\033[31marA\033[mnsi ")
-                imgui.text_ansi_colored("Eg\033[31mgAn\033[msi ", 0.2, 1.0, 0.0)
+                imgui.text_ansi_colored(
+                    "Eg\033[31mgAn\033[msi ", 0.2, 1.0, 0.0
+                )
                 imgui.extra.text_ansi_colored("Eggs", 0.2, 1.0, 0.0)
             imgui.end()
 
@@ -74,7 +74,9 @@ def impl_glfw_init():
     glfw.window_hint(glfw.OPENGL_FORWARD_COMPAT, gl.GL_TRUE)
 
     # Create a windowed mode window and its OpenGL context
-    window = glfw.create_window(int(width), int(height), window_name, None, None)
+    window = glfw.create_window(
+        int(width), int(height), window_name, None, None
+    )
     glfw.make_context_current(window)
 
     if not window:

--- a/doc/examples/integrations_pygame.py
+++ b/doc/examples/integrations_pygame.py
@@ -1,7 +1,5 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
+#!/usr/bin/env python3
 
-from __future__ import absolute_import
 from imgui.integrations.pygame import PygameRenderer
 import OpenGL.GL as gl
 import imgui
@@ -13,7 +11,9 @@ def main():
     pygame.init()
     size = 800, 600
 
-    pygame.display.set_mode(size, pygame.DOUBLEBUF | pygame.OPENGL | pygame.RESIZABLE)
+    pygame.display.set_mode(
+        size, pygame.DOUBLEBUF | pygame.OPENGL | pygame.RESIZABLE
+    )
 
     imgui.create_context()
     impl = PygameRenderer()
@@ -34,7 +34,6 @@ def main():
 
         if imgui.begin_main_menu_bar():
             if imgui.begin_menu("File", True):
-
                 clicked_quit, selected_quit = imgui.menu_item(
                     "Quit", "Cmd+Q", False, True
                 )

--- a/doc/examples/integrations_pyglet.py
+++ b/doc/examples/integrations_pyglet.py
@@ -1,7 +1,5 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
+#!/usr/bin/env python3
 
-from __future__ import absolute_import
 from pyglet import gl
 from testwindow import show_test_window
 import pyglet
@@ -16,7 +14,6 @@ from imgui.integrations.pyglet import create_renderer
 
 
 def main():
-
     window = pyglet.window.Window(width=1280, height=720, resizable=True)
     gl.glClearColor(1, 1, 1, 1)
     imgui.create_context()
@@ -30,7 +27,6 @@ def main():
         imgui.new_frame()
         if imgui.begin_main_menu_bar():
             if imgui.begin_menu("File", True):
-
                 clicked_quit, selected_quit = imgui.menu_item(
                     "Quit", "Cmd+Q", False, True
                 )
@@ -52,7 +48,9 @@ def main():
                 imgui.text_colored("Eggs", 0.2, 1.0, 0.0)
 
                 imgui.text_ansi("B\033[31marA\033[mnsi ")
-                imgui.text_ansi_colored("Eg\033[31mgAn\033[msi ", 0.2, 1.0, 0.0)
+                imgui.text_ansi_colored(
+                    "Eg\033[31mgAn\033[msi ", 0.2, 1.0, 0.0
+                )
 
             imgui.end()
 

--- a/doc/examples/integrations_pysdl2.py
+++ b/doc/examples/integrations_pysdl2.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
+#!/usr/bin/env python3
 
 from imgui.integrations.sdl2 import SDL2Renderer
 from testwindow import show_test_window
@@ -31,7 +30,6 @@ def main():
 
         if imgui.begin_main_menu_bar():
             if imgui.begin_menu("File", True):
-
                 clicked_quit, selected_quit = imgui.menu_item(
                     "Quit", "Cmd+Q", False, True
                 )
@@ -82,10 +80,14 @@ def impl_pysdl2_init():
     SDL_GL_SetAttribute(SDL_GL_ACCELERATED_VISUAL, 1)
     SDL_GL_SetAttribute(SDL_GL_MULTISAMPLEBUFFERS, 1)
     SDL_GL_SetAttribute(SDL_GL_MULTISAMPLESAMPLES, 8)
-    SDL_GL_SetAttribute(SDL_GL_CONTEXT_FLAGS, SDL_GL_CONTEXT_FORWARD_COMPATIBLE_FLAG)
+    SDL_GL_SetAttribute(
+        SDL_GL_CONTEXT_FLAGS, SDL_GL_CONTEXT_FORWARD_COMPATIBLE_FLAG
+    )
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 4)
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 1)
-    SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE)
+    SDL_GL_SetAttribute(
+        SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE
+    )
 
     SDL_SetHint(SDL_HINT_MAC_CTRL_CLICK_EMULATE_RIGHT_CLICK, b"1")
     SDL_SetHint(SDL_HINT_VIDEO_HIGHDPI_DISABLED, b"1")
@@ -117,7 +119,8 @@ def impl_pysdl2_init():
     SDL_GL_MakeCurrent(window, gl_context)
     if SDL_GL_SetSwapInterval(1) < 0:
         print(
-            "Warning: Unable to set VSync! SDL Error: " + SDL_GetError().decode("utf-8")
+            "Warning: Unable to set VSync! SDL Error: "
+            + SDL_GetError().decode("utf-8")
         )
         sys.exit(1)
 

--- a/doc/examples/plots.py
+++ b/doc/examples/plots.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
+#!/usr/bin/env python3
 
 from array import array
 from imgui.integrations.glfw import GlfwRenderer
@@ -80,7 +79,9 @@ def impl_glfw_init():
     glfw.window_hint(glfw.OPENGL_FORWARD_COMPAT, gl.GL_TRUE)
 
     # Create a windowed mode window and its OpenGL context
-    window = glfw.create_window(int(width), int(height), window_name, None, None)
+    window = glfw.create_window(
+        int(width), int(height), window_name, None, None
+    )
     glfw.make_context_current(window)
 
     if not window:

--- a/doc/examples/testwindow.py
+++ b/doc/examples/testwindow.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
+#!/usr/bin/env python3
 
 from array import array
 import colorsys
@@ -234,7 +233,6 @@ filtering_filter = None  # Todo - bind this in cimgui.pxd
 
 
 def show_help_marker(desc):
-
     imgui.text_disabled("(?)")
     if imgui.is_item_hovered():
         imgui.begin_tooltip()
@@ -269,13 +267,14 @@ def show_example_app_main_menu_bar():
 
 
 def show_example_menu_file():
-
     global example_menu_file_enabled
     global example_menu_file_options_f
     global example_menu_file_options_n
     global example_menu_file_options_b
 
-    imgui.menu_item(label="(dummy menu)", shortcut=None, selected=False, enabled=False)
+    imgui.menu_item(
+        label="(dummy menu)", shortcut=None, selected=False, enabled=False
+    )
     if imgui.menu_item("New"):
         pass
     if imgui.menu_item(label="Open", shortcut="Ctrl+O"):
@@ -351,7 +350,6 @@ def show_example_menu_file():
 
 
 def show_test_window():
-
     global show_app_main_menu_bar
     global show_app_console
     global show_app_log
@@ -574,7 +572,9 @@ def show_test_window():
     imgui.set_next_window_size(550, 680, condition=imgui.FIRST_USE_EVER)
 
     # Main body of the Demo window starts here.
-    if not imgui.begin(label="ImGui Demo", closable=no_close, flags=window_flags):
+    if not imgui.begin(
+        label="ImGui Demo", closable=no_close, flags=window_flags
+    ):
         # Early out if the window is collapsed, as an optimization.
         imgui.end()
         sys.exit(0)
@@ -597,7 +597,9 @@ def show_test_window():
 
         if imgui.begin_menu(label="Examples"):
             clicked, show_app_main_menu_bar = imgui.menu_item(
-                label="Main menu bar", shortcut=None, selected=show_app_main_menu_bar
+                label="Main menu bar",
+                shortcut=None,
+                selected=show_app_main_menu_bar,
             )
             clicked, show_app_console = imgui.menu_item(
                 label="Console", shortcut=None, selected=show_app_console
@@ -614,7 +616,9 @@ def show_test_window():
                 selected=show_app_property_editor,
             )
             clicked, show_app_long_text = imgui.menu_item(
-                label="Long text display", shortcut=None, selected=show_app_long_text
+                label="Long text display",
+                shortcut=None,
+                selected=show_app_long_text,
             )
             clicked, show_app_auto_resize = imgui.menu_item(
                 label="Auto-resizing window",
@@ -627,7 +631,9 @@ def show_test_window():
                 selected=show_app_constrained_resize,
             )
             clicked, show_app_simple_overlay = imgui.menu_item(
-                label="Simple overlay", shortcut=None, selected=show_app_simple_overlay
+                label="Simple overlay",
+                shortcut=None,
+                selected=show_app_simple_overlay,
             )
             clicked, show_app_window_titles = imgui.menu_item(
                 label="Manipulating window titles",
@@ -646,10 +652,14 @@ def show_test_window():
                 label="Metrics", shortcut=None, selected=show_app_metrics
             )
             clicked, show_app_style_editor = imgui.menu_item(
-                label="Style Editor", shortcut=None, selected=show_app_style_editor
+                label="Style Editor",
+                shortcut=None,
+                selected=show_app_style_editor,
             )
             clicked, show_app_about = imgui.menu_item(
-                label="About Dear ImGui", shortcut=None, selected=show_app_about
+                label="About Dear ImGui",
+                shortcut=None,
+                selected=show_app_about,
             )
             imgui.end_menu()
 
@@ -659,7 +669,6 @@ def show_test_window():
 
         show, _ = imgui.collapsing_header("Help")
         if show:
-
             imgui.text("PROGRAMMER GUIDE:")
             imgui.bullet_text(
                 "Please see the _show_demo_window() code in imgui_demo.cpp. <- you are here!"
@@ -679,11 +688,9 @@ def show_test_window():
 
     show, _ = imgui.collapsing_header("Configuration")
     if show:
-
         io = imgui.get_io()
 
         if imgui.tree_node("Configuration##2"):
-
             # TODO - for some reason this causes an error about space not being mapped, which doesn't happen in the C++ version
             clicked, io.config_flags = imgui.checkbox_flags(
                 "io.ConfigFlags: NavEnableKeyboard",
@@ -709,7 +716,9 @@ def show_test_window():
                 "Instruct navigation to move the mouse cursor. See comment for ImGuiConfigFlags_NavEnableSetMousePos."
             )
             clicked, io.config_flags = imgui.checkbox_flags(
-                "io.ConfigFlags: NoMouse", io.config_flags, imgui.CONFIG_NO_MOUSE
+                "io.ConfigFlags: NoMouse",
+                io.config_flags,
+                imgui.CONFIG_NO_MOUSE,
             )
             if (
                 io.config_flags & imgui.CONFIG_NO_MOUSE
@@ -726,7 +735,8 @@ def show_test_window():
                 "Instruct back-end to not alter mouse cursor shape and visibility."
             )
             imgui.checkbox(
-                label="io.ConfigInputTextCursorBlink", state=io.config_cursor_blink
+                label="io.ConfigInputTextCursorBlink",
+                state=io.config_cursor_blink,
             )
             imgui.same_line()
             show_help_marker(
@@ -740,7 +750,9 @@ def show_test_window():
             show_help_marker(
                 "Enable resizing of windows from their edges and from the lower-left corner.\nThis requires (io.BackendFlags & ImGuiBackendFlags_HasMouseCursors) because it needs mouse cursor feedback."
             )
-            imgui.checkbox(label="io.MouseDrawCursor", state=io.mouse_draw_cursor)
+            imgui.checkbox(
+                label="io.MouseDrawCursor", state=io.mouse_draw_cursor
+            )
             imgui.same_line()
             show_help_marker(
                 "Instruct Dear ImGui to render a mouse cursor for you. Note that a mouse cursor rendered via your application GPU rendering path will feel more laggy than hardware cursor, but will be more in sync with your other visuals.\n\nSome desktop applications may use both kinds of cursors (e.g. enable software cursor only when resizing/dragging something)."
@@ -749,11 +761,12 @@ def show_test_window():
             imgui.separator()
 
         if imgui.tree_node("Backend Flags"):
-
             backend_flags = io.backend_flags
             # Make a local copy to avoid modifying the back-end flags.
             clicked, backend_flags = imgui.checkbox_flags(
-                "io.BackendFlags: HasGamepad", backend_flags, imgui.BACKEND_HAS_GAMEPAD
+                "io.BackendFlags: HasGamepad",
+                backend_flags,
+                imgui.BACKEND_HAS_GAMEPAD,
             )
             clicked, backend_flags = imgui.checkbox_flags(
                 "io.BackendFlags: HasMouseCursors",
@@ -769,14 +782,12 @@ def show_test_window():
             imgui.separator()
 
         if imgui.tree_node("Style"):
-
             # TODO - implement show_style_editor
             imgui.show_style_editor()
             imgui.tree_pop()
             imgui.separator()
 
         if imgui.tree_node("Capture/Logging"):
-
             # TODO -- check to see if pyimgui actually implements this functionality, then add it in
 
             # imgui.text_wrapped("The logging API redirects all text output so you can easily capture the content of a window or a block. Tree nodes can be automatically expanded.")
@@ -803,12 +814,16 @@ def show_test_window():
             clicked, no_menu = imgui.checkbox(label="No menu", state=no_menu)
             clicked, no_move = imgui.checkbox(label="No move", state=no_move)
             imgui.same_line(150)
-            clicked, no_resize = imgui.checkbox(label="No resize", state=no_resize)
+            clicked, no_resize = imgui.checkbox(
+                label="No resize", state=no_resize
+            )
             imgui.same_line(300)
             clicked, no_collapse = imgui.checkbox(
                 label="No collapse", state=no_collapse
             )
-            clicked, no_close = imgui.checkbox(label="No close", state=no_close)
+            clicked, no_close = imgui.checkbox(
+                label="No close", state=no_close
+            )
             imgui.same_line(150)
             clicked, no_nav = imgui.checkbox(label="No nav", state=no_nav)
 
@@ -905,14 +920,19 @@ def show_test_window():
                 "ESCAPE to revert.\n\nPROGRAMMER:\nYou can use the ImGuiInputTextFlags_CallbackResize facility if you need to wire InputText() to a dynamic string type. See misc/stl/imgui_stl.h for an example (this is not demonstrated in imgui_demo.cpp)."
             )
 
-            changed, widgets_basic_i0 = imgui.input_int("input int", widgets_basic_i0)
+            changed, widgets_basic_i0 = imgui.input_int(
+                "input int", widgets_basic_i0
+            )
             imgui.same_line()
             show_help_marker(
                 "You can apply arithmetic operators +,*,/ on numerical values.\n  e.g. [ 100 ], input '*2', result becomes [ 200 ]\nUse +- to subtract.\n"
             )
 
             changed, widgets_basic_f0 = imgui.input_float(
-                label="input float", value=widgets_basic_f0, step=0.01, step_fast=1.0
+                label="input float",
+                value=widgets_basic_f0,
+                step=0.01,
+                step_fast=1.0,
             )
 
             changed, widgets_basic_d0 = imgui.input_double(
@@ -935,7 +955,9 @@ def show_test_window():
                 "input float4", *widgets_basic_vec4a
             )
 
-            changed, widgets_basic_i1 = imgui.drag_int("drag int", widgets_basic_i1, 1)
+            changed, widgets_basic_i1 = imgui.drag_int(
+                "drag int", widgets_basic_i1, 1
+            )
             imgui.same_line()
             show_help_marker(
                 "Click and drag to edit value.\nHold SHIFT/ALT for faster/slower edit.\nDouble-click or CTRL+click to input value."
@@ -949,7 +971,12 @@ def show_test_window():
                 "drag float", widgets_basic_f1, 0.005
             )
             changed, widgets_basic_f2 = imgui.drag_float(
-                "drag small float", widgets_basic_f2, 0.0001, 0.0, 0.0, "%.06f ns"
+                "drag small float",
+                widgets_basic_f2,
+                0.0001,
+                0.0,
+                0.0,
+                "%.06f ns",
             )
 
             changed, widgets_basic_i1_1 = imgui.slider_int(
@@ -1016,7 +1043,6 @@ def show_test_window():
         # //        imgui.text("This will be displayed only once.");
 
         if imgui.tree_node("Trees"):
-
             if imgui.tree_node("Basic trees"):
                 for i in range(5):
                     if imgui.tree_node(text="Child " + str(i)):
@@ -1079,7 +1105,8 @@ def show_test_window():
 
         if imgui.tree_node("Collapsing Headers"):
             clicked, collapsing_headers_closable_group = imgui.checkbox(
-                label="Enable extra group", state=collapsing_headers_closable_group
+                label="Enable extra group",
+                state=collapsing_headers_closable_group,
             )
 
             show, _ = imgui.collapsing_header("Header")
@@ -1098,7 +1125,9 @@ def show_test_window():
 
         if imgui.tree_node("Bullets"):
             imgui.bullet_text("Bullet point 1")
-            imgui.bullet_text("Bullet point 2" + os.linesep + "newOn multiple lines")
+            imgui.bullet_text(
+                "Bullet point 2" + os.linesep + "newOn multiple lines"
+            )
             imgui.bullet()
             imgui.text("Bullet point 3 (two calls)")
             imgui.bullet()
@@ -1112,7 +1141,9 @@ def show_test_window():
                 imgui.text_colored(text="Yellow", r=1.0, g=1.0, b=0.0, a=1.0)
                 imgui.text_disabled("Disabled")
                 imgui.same_line()
-                show_help_marker("The TextDisabled color is stored in ImGuiStyle.")
+                show_help_marker(
+                    "The TextDisabled color is stored in ImGuiStyle."
+                )
                 imgui.tree_pop()
 
             if imgui.tree_node("Word Wrapping"):
@@ -1237,12 +1268,16 @@ def show_test_window():
             if imgui.is_item_hovered():
                 imgui.begin_tooltip()
                 region_sz = 32.0
-                region_x = imgui.get_mouse_position().x - pos.x - region_sz * 0.5
+                region_x = (
+                    imgui.get_mouse_position().x - pos.x - region_sz * 0.5
+                )
                 if region_x < 0.0:
                     region_x = 0.0
                 elif region_x > my_tex_w - region_sz:
                     region_x = my_tex_w - region_sz
-                region_y = imgui.get_mouse_position().y - pos.y - region_sz * 0.5
+                region_y = (
+                    imgui.get_mouse_position().y - pos.y - region_sz * 0.5
+                )
                 if region_y < 0.0:
                     region_y = 0.0
                 elif region_y > my_tex_h - region_sz:
@@ -1295,7 +1330,6 @@ def show_test_window():
             imgui.tree_pop()
 
         if imgui.tree_node("Combo"):
-
             # Expose flags as checkbox for the demo
             clicked, combo_flags = imgui.checkbox_flags(
                 "ImGuiComboFlags_PopupAlignLeft",
@@ -1353,23 +1387,24 @@ def show_test_window():
             imgui.tree_pop()
 
         if imgui.tree_node("Selectables"):
-
             # Selectable() has 2 overloads:
             #  The one taking "bool selected" as a read-only selection information. When Selectable() has been clicked is returns True and you can alter selection state accordingly.
             #  The one taking "bool* p_selected" as a read-write selection information (convenient in some cases)
             # The earlier is more flexible, as in real application your selection may be stored in a different manner (in flags within objects, as an external list, etc).
 
             if imgui.tree_node("Basic"):
-
                 _, selectables_basic_selection[0] = imgui.selectable(
-                    label="1. I am selectable", selected=selectables_basic_selection[0]
+                    label="1. I am selectable",
+                    selected=selectables_basic_selection[0],
                 )
                 _, selectables_basic_selection[1] = imgui.selectable(
-                    label="2. I am selectable", selected=selectables_basic_selection[1]
+                    label="2. I am selectable",
+                    selected=selectables_basic_selection[1],
                 )
                 imgui.text("3. I am not selectable")
                 _, selectables_basic_selection[3] = imgui.selectable(
-                    label="4. I am selectable", selected=selectables_basic_selection[3]
+                    label="4. I am selectable",
+                    selected=selectables_basic_selection[3],
                 )
                 clicked, selectables_basic_selection[4] = imgui.selectable(
                     label="5. I am double clickable",
@@ -1384,7 +1419,6 @@ def show_test_window():
                 imgui.tree_pop()
 
             if imgui.tree_node("Selection State: Single Selection"):
-
                 for n in range(5):
                     buf = "Object " + str(n)
                     clicked, _ = imgui.selectable(
@@ -1396,13 +1430,16 @@ def show_test_window():
                 imgui.tree_pop()
 
             if imgui.tree_node("Selection State: Multiple Selection"):
-
-                show_help_marker("Hold CTRL and click to select multiple items.")
+                show_help_marker(
+                    "Hold CTRL and click to select multiple items."
+                )
 
                 for n in range(5):
-
                     buf = "Object " + str(n)
-                    clicked, selectables_basic_selection_2[n] = imgui.selectable(
+                    (
+                        clicked,
+                        selectables_basic_selection_2[n],
+                    ) = imgui.selectable(
                         label=buf, selected=selectables_basic_selection_2[n]
                     )
                     if clicked:
@@ -1410,14 +1447,16 @@ def show_test_window():
                             not imgui.get_io().key_ctrl
                         ):  # Clear selection when CTRL is not held
                             selectables_basic_selection_2 = list(
-                                map(lambda b: False, selectables_basic_selection_2)
+                                map(
+                                    lambda b: False,
+                                    selectables_basic_selection_2,
+                                )
                             )
                             selectables_basic_selection_2[n] = True
 
                 imgui.tree_pop()
 
             if imgui.tree_node("Rendering more text into the same line"):
-
                 #  Using the Selectable() override that takes "bool* p_selected" parameter and toggle your booleans automatically.
                 clicked, selectables_basic_selected_2[0] = imgui.selectable(
                     label="main.c", selected=selectables_basic_selected_2[0]
@@ -1437,23 +1476,27 @@ def show_test_window():
                 imgui.tree_pop()
 
             if imgui.tree_node("In columns"):
-
                 imgui.columns(count=3, identifier=None, border=False)
                 for index in range(len(selectables_basic_selected_3)):
                     label = "Item " + str(index)
-                    clicked, selectables_basic_selected_3[index] = imgui.selectable(
-                        label=label, selected=selectables_basic_selected_3[index]
+                    (
+                        clicked,
+                        selectables_basic_selected_3[index],
+                    ) = imgui.selectable(
+                        label=label,
+                        selected=selectables_basic_selected_3[index],
                     )
                     imgui.next_column()
                 imgui.columns(1)
                 imgui.tree_pop()
 
             if imgui.tree_node("Grid"):
-
                 for index in range(len(selectables_basic_selected_4)):
-
                     imgui.push_id(str(index))
-                    clicked, selectables_basic_selected_4[index] = imgui.selectable(
+                    (
+                        clicked,
+                        selectables_basic_selected_4[index],
+                    ) = imgui.selectable(
                         label="Sailor",
                         selected=selectables_basic_selected_4[index],
                         flags=0,
@@ -1461,7 +1504,6 @@ def show_test_window():
                         height=50,
                     )
                     if clicked:
-
                         x = index % 4
                         y = index // 4
                         if x > 0:
@@ -1489,9 +1531,10 @@ def show_test_window():
             imgui.tree_pop()
 
         if imgui.tree_node("Filtered Text Input"):
-
             clicked, filtered_text_input_buf1 = imgui.input_text(
-                label="default", value=filtered_text_input_buf1, buffer_length=64
+                label="default",
+                value=filtered_text_input_buf1,
+                buffer_length=64,
             )
             clicked, filtered_text_input_buf2 = imgui.input_text(
                 label="decimal",
@@ -1531,7 +1574,8 @@ def show_test_window():
                 label="password",
                 value=filtered_text_input_buf_pass,
                 buffer_length=64,
-                flags=imgui.INPUT_TEXT_PASSWORD | imgui.INPUT_TEXT_CHARS_NO_BLANK,
+                flags=imgui.INPUT_TEXT_PASSWORD
+                | imgui.INPUT_TEXT_CHARS_NO_BLANK,
             )
             imgui.same_line()
             show_help_marker(
@@ -1552,7 +1596,6 @@ def show_test_window():
             imgui.tree_pop()
 
         if imgui.tree_node("Multi-line Text Input"):
-
             show_help_marker(
                 "You can use the ImGuiInputTextFlags_CallbackResize facility if you need to wire InputTextMultiline() to a dynamic string type. See misc/stl/imgui_stl.h for an example. (This is not demonstrated in imgui_demo.cpp)"
             )
@@ -1560,7 +1603,9 @@ def show_test_window():
                 label="Read-only", state=multi_line_text_input_read_only
             )
             flags = imgui.INPUT_TEXT_ALLOW_TAB_INPUT | (
-                imgui.INPUT_TEXT_READ_ONLY if multi_line_text_input_read_only else 0
+                imgui.INPUT_TEXT_READ_ONLY
+                if multi_line_text_input_read_only
+                else 0
             )
             changed, multi_line_text_input_text = imgui.input_text_multiline(
                 label="##source",
@@ -1573,7 +1618,6 @@ def show_test_window():
             imgui.tree_pop()
 
         if imgui.tree_node("Plots Widgets"):
-
             clicked, plots_widgets_animate = imgui.checkbox(
                 label="Animate", state=plots_widgets_animate
             )
@@ -1586,7 +1630,9 @@ def show_test_window():
 
             # Create a dummy array of contiguous float values to plot
             # Tip: If your float aren't contiguous but part of a structure, you can pass a pointer to your first float and the sizeof() of your structure in the Stride parameter.
-            if (not plots_widgets_animate) or plots_widgets_refresh_time == 0.0:
+            if (
+                not plots_widgets_animate
+            ) or plots_widgets_refresh_time == 0.0:
                 plots_widgets_refresh_time = imgui.get_time()
                 print(plots_widgets_refresh_time)
 
@@ -1647,7 +1693,9 @@ def show_test_window():
 
             # Animate a simple progress bar
             if plots_widgets_animate:
-                plots_progress += plots_progress_dir * 0.4 * imgui.get_io().delta_time
+                plots_progress += (
+                    plots_progress_dir * 0.4 * imgui.get_io().delta_time
+                )
             if plots_progress >= +1.1:
                 plots_progress = +1.1
                 plots_progress_dir *= -1.0
@@ -1676,12 +1724,12 @@ def show_test_window():
             imgui.tree_pop()
 
         if imgui.tree_node("Color/Picker Widgets"):
-
             checked, color_picker_alpha_preview = imgui.checkbox(
                 label="With Alpha Preview", state=color_picker_alpha_preview
             )
             checked, color_picker_alpha_half_preview = imgui.checkbox(
-                label="With Half Alpha Preview", state=color_picker_alpha_half_preview
+                label="With Half Alpha Preview",
+                state=color_picker_alpha_half_preview,
             )
             checked, color_picker_drag_and_drop = imgui.checkbox(
                 label="With Drag and Drop", state=color_picker_drag_and_drop
@@ -1703,7 +1751,11 @@ def show_test_window():
 
             misc_flags = (
                 (imgui.COLOR_EDIT_HDR if color_picker_hdr else 0)
-                | (0 if color_picker_drag_and_drop else imgui.COLOR_EDIT_NO_DRAG_DROP)
+                | (
+                    0
+                    if color_picker_drag_and_drop
+                    else imgui.COLOR_EDIT_NO_DRAG_DROP
+                )
                 | (
                     imgui.COLOR_EDIT_ALPHA_PREVIEW_HALF
                     if color_picker_alpha_half_preview
@@ -1713,7 +1765,11 @@ def show_test_window():
                         else 0
                     )
                 )
-                | (0 if color_picker_options_menu else imgui.COLOR_EDIT_NO_OPTIONS)
+                | (
+                    0
+                    if color_picker_options_menu
+                    else imgui.COLOR_EDIT_NO_OPTIONS
+                )
             )
 
             imgui.text("Color widget:")
@@ -1730,12 +1786,16 @@ def show_test_window():
 
             imgui.text("Color widget HSV with Alpha:")
             changed, color_picker_color = imgui.color_edit4(
-                "MyColor##2", *color_picker_color, imgui.COLOR_EDIT_HSV | misc_flags
+                "MyColor##2",
+                *color_picker_color,
+                imgui.COLOR_EDIT_HSV | misc_flags
             )
 
             imgui.text("Color widget with Float Display:")
             changed, color_picker_color = imgui.color_edit4(
-                "MyColor##2f", *color_picker_color, imgui.COLOR_EDIT_FLOAT | misc_flags
+                "MyColor##2f",
+                *color_picker_color,
+                imgui.COLOR_EDIT_FLOAT | misc_flags
             )
 
             # imgui.text("Color button with Picker:");
@@ -1855,7 +1915,6 @@ def show_test_window():
             imgui.tree_pop()
 
         if imgui.tree_node("Range Widgets"):
-
             # TODO - this should call drag_float_range2 instead, so implement it and do it
             # changed, (range_widgets_begin, range_widgets_end) = imgui.drag_float2(label="range",
             #                   value0=range_widgets_begin,
@@ -1868,7 +1927,6 @@ def show_test_window():
             imgui.tree_pop()
 
         if imgui.tree_node("Data Types"):
-
             # // The DragScalar/InputScalar/SliderScalar functions allow various data types: signed/unsigned int/long long and float/double
             # // To avoid polluting the public API with all possible combinations, we use the ImGuiDataType enum to pass the type,
             # // and passing all arguments by address.
@@ -1955,7 +2013,6 @@ def show_test_window():
             imgui.tree_pop()
 
         if imgui.tree_node("Multi-component Widgets"):
-
             changed, (
                 multi_component_vec4f[0],
                 multi_component_vec4f[1],
@@ -2175,7 +2232,6 @@ def show_test_window():
             imgui.tree_pop()
 
         if imgui.tree_node("Vertical Sliders"):
-
             # const float spacing = 4;
             # imgui.push_style_var(ImGuiStyleVar_ItemSpacing, ImVec2(spacing, spacing));
 
@@ -2238,7 +2294,6 @@ def show_test_window():
             imgui.tree_pop()
 
         if imgui.tree_node("Drag and Drop"):
-
             # {
             #     // ColorEdit widgets automatically act as drag source and drag target.
             #     // They are using standardized payload strings IMGUI_PAYLOAD_TYPE_COLOR_3F and IMGUI_PAYLOAD_TYPE_COLOR_4F to allow your own widgets
@@ -2322,7 +2377,6 @@ def show_test_window():
             imgui.tree_pop()
 
         if imgui.tree_node("Querying Status (Active/Focused/Hovered etc.)"):
-
             # // Display the value of IsItemHovered() and other common item state functions. Note that the flags can be combined.
             # // (because BulletText is an item itself and that would affect the output of IsItemHovered() we pass all state in a single call to simplify the code).
             # static int item_type = 1;
@@ -2443,7 +2497,8 @@ def show_test_window():
     if show:
         if imgui.tree_node("Child regions"):
             checked, child_regions_disable_mouse_wheel = imgui.checkbox(
-                label="Disable Mouse Wheel", state=child_regions_disable_mouse_wheel
+                label="Disable Mouse Wheel",
+                state=child_regions_disable_mouse_wheel,
             )
             checked, child_regions_disable_menu = imgui.checkbox(
                 label="Disable Menu", state=child_regions_disable_menu
@@ -2892,7 +2947,9 @@ def show_test_window():
                 imgui.open_popup("select")
             imgui.same_line()
             imgui.text_unformatted(
-                "<None>" if popups_selected_fish == -1 else names[popups_selected_fish]
+                "<None>"
+                if popups_selected_fish == -1
+                else names[popups_selected_fish]
             )
             if imgui.begin_popup("select"):
                 imgui.text("Aquarium")
@@ -2909,7 +2966,9 @@ def show_test_window():
             if imgui.begin_popup("toggle"):
                 for i in range(len(names)):
                     clicked, popups_toggles[i] = imgui.menu_item(
-                        label=names[i], shortcut=None, selected=popups_toggles[i]
+                        label=names[i],
+                        shortcut=None,
+                        selected=popups_toggles[i],
                     )
                 if imgui.begin_menu("Sub-menu"):
                     imgui.menu_item("Click me")
@@ -2925,7 +2984,9 @@ def show_test_window():
                 if imgui.begin_popup("another popup"):
                     for i in range(len(names)):
                         clicked, popups_toggles[i] = imgui.menu_item(
-                            label=names[i], shortcut=None, selected=popups_toggles[i]
+                            label=names[i],
+                            shortcut=None,
+                            selected=popups_toggles[i],
                         )
                     if imgui.begin_menu("Sub-menu"):
                         imgui.menu_item("Click me")
@@ -2949,7 +3010,9 @@ def show_test_window():
             # // For more advanced uses you may want to replicate and cuztomize this code. This the comments inside BeginPopupContextItem() implementation.
 
             imgui.text(
-                "Value = " + str(context_menus_value) + " (<-- right-click here)"
+                "Value = "
+                + str(context_menus_value)
+                + " (<-- right-click here)"
             )
             if imgui.begin_popup_context_item("item context menu"):
                 changed, _ = imgui.selectable("Set to zero")
@@ -2986,7 +3049,6 @@ def show_test_window():
             imgui.tree_pop()
 
         if imgui.tree_node("Modals"):
-
             imgui.text_wrapped(
                 "Modal windows are like popups but the user cannot close them by clicking outside the window."
             )
@@ -2994,7 +3056,9 @@ def show_test_window():
             if imgui.button(label="Delete.."):
                 imgui.open_popup("Delete?")
             if imgui.begin_popup_modal(
-                title="Delete?", visible=None, flags=imgui.WINDOW_ALWAYS_AUTO_RESIZE
+                title="Delete?",
+                visible=None,
+                flags=imgui.WINDOW_ALWAYS_AUTO_RESIZE,
             )[0]:
                 imgui.text(
                     "All those beautiful files will be deleted.\nThis operation cannot be undone!\n\n"
@@ -3203,7 +3267,11 @@ def show_test_window():
                 if borders_h_borders and imgui.get_column_index() == 0:
                     imgui.separator()
                 imgui.text(
-                    char_add_to_a(i) + " " + char_add_to_a(i) + " " + char_add_to_a(i)
+                    char_add_to_a(i)
+                    + " "
+                    + char_add_to_a(i)
+                    + " "
+                    + char_add_to_a(i)
                 )
                 imgui.text(
                     "Width "
@@ -3287,7 +3355,10 @@ def show_test_window():
         imgui.text("WantTextInput: " + str(io.want_text_input))
         imgui.text("WantSetMousePos: " + str(io.want_set_mouse_pos))
         imgui.text(
-            "NavActive: " + str(io.nav_active) + "NavVisible: " + str(io.nav_visible)
+            "NavActive: "
+            + str(io.nav_active)
+            + "NavVisible: "
+            + str(io.nav_visible)
         )
 
         #     if imgui.tree_node("Keyboard, Mouse & Navigation State"):

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # pyimgui documentation build configuration file, created by
 # sphinx-quickstart on Mon Oct 31 22:03:15 2016.
 #

--- a/doc/source/convert_readme.py
+++ b/doc/source/convert_readme.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
+#!/usr/bin/env python3
+
 """
 This scripts handles conversion of Markdown README into rst for inclusion
 in Sphinx documentation.

--- a/doc/source/custom_directives.py
+++ b/doc/source/custom_directives.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from docutils import nodes
 from docutils.parsers.rst import Directive
 from docutils.parsers.rst import directives

--- a/doc/source/gen_example.py
+++ b/doc/source/gen_example.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from inspect import cleandoc
 import os
 

--- a/imgui/__init__.py
+++ b/imgui/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 VERSION = (2, 0, 0)  # PEP 386
 __version__ = ".".join([str(x) for x in VERSION])
 

--- a/imgui/ansifeed.pxd
+++ b/imgui/ansifeed.pxd
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # distutils: language = c++
 # distutils: sources = ansifeed-cpp/AnsiTextColored.cpp
 # distutils: include_dirs = imgui-cpp ansifeed-cpp

--- a/imgui/cimgui.pxd
+++ b/imgui/cimgui.pxd
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # distutils: language = c++
 # distutils: include_dirs = imgui-cpp
 """
@@ -2239,4 +2238,4 @@ cdef extern from "imgui.h" namespace "ImGui":
     void* MemAlloc(size_t size) except + # ✗
     void MemFree(void* ptr) except + # ✗
 
-    
+

--- a/imgui/integrations/__init__.py
+++ b/imgui/integrations/__init__.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import
-
-
 def compute_fb_scale(window_size, frame_buffer_size):
     win_width, win_height = window_size
     fb_width, fb_height = frame_buffer_size

--- a/imgui/integrations/cocos2d.py
+++ b/imgui/integrations/cocos2d.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import
-
 import cocos
 
 import imgui

--- a/imgui/integrations/glfw.py
+++ b/imgui/integrations/glfw.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import
-
 import glfw
 import imgui
 

--- a/imgui/integrations/glumpy.py
+++ b/imgui/integrations/glumpy.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import numpy as np
 
 import ctypes
@@ -366,4 +365,4 @@ class GlumpyRenderer(BaseOpenGLRenderer):
         
     def _invalidate_device_objects(self):
         pass
-    
+

--- a/imgui/integrations/opengl.py
+++ b/imgui/integrations/opengl.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import
-
 import OpenGL.GL as gl
 import imgui
 import ctypes

--- a/imgui/integrations/pygame.py
+++ b/imgui/integrations/pygame.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from .opengl import FixedPipelineRenderer
 
 import pygame
@@ -149,4 +147,4 @@ class PygameRenderer(FixedPipelineRenderer):
         
         
         
-        
+

--- a/imgui/integrations/pyglet.py
+++ b/imgui/integrations/pyglet.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import
 import warnings
 from distutils.version import LooseVersion
 

--- a/imgui/integrations/sdl2.py
+++ b/imgui/integrations/sdl2.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import
-
 from sdl2 import *
 
 import imgui

--- a/imgui/internal.pxd
+++ b/imgui/internal.pxd
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # distutils: language = c++
 # distutils: include_dirs = imgui-cpp
 """
@@ -683,4 +682,4 @@ cdef extern from "imgui_internal.h" namespace "ImGui":
     
     
     
-    
+

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 import sys
 import sysconfig
@@ -190,4 +189,5 @@ setup(
 
         'Topic :: Games/Entertainment',
     ],
+    python_requires="<3.12,>=3.6",
 )

--- a/tests/test_crazy_callbacks.py
+++ b/tests/test_crazy_callbacks.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import glfw
 import OpenGL.GL as gl
 


### PR DESCRIPTION
Per the [readme](https://github.com/pyimgui/pyimgui/blob/723022d87de8040d1c4a66f53288dcfd7d2274d3/README.md#project-distribution), the only supported versions of Python/PyPy are:
* py36
* py37, pp37
* py38, pp38
* py39, pp39
* py310
* py311

As such, I added this requirement in `setup.py`. As it stands, you can still install `imgui==2.0` with Python 2. This PR fixes this issue. **However, I have not tested this on PyPy.** I recommend testing this before merging.  I also recommend releasing this as pyimgui 2.0.1 OR pyimgui 2.0.0.post1, then yanking 2.0.0. This will prevent a user from accidentally installing pyimgui 2.0.0 on Python 2 (or other unsupported versions), but will also not break existing projects.

Additionally, I changed the things @learn-more had mentioned in #311. These things include changing all shebangs to use `python3`, removing all `coding: utf-8` lines as these are only required for Python 2, and removing `from __future__ import absolute_import` as again, this was only required for Python 2.

Lastly, I ran black on the examples to fix line length and other formatting issues. Black also has issues with a lot of other Python files in the project, but I wanted to restrict this PR. With that said, I can run black on the entire project in this or a separate PR to standardize the whole project.