### PR TITLE
OpenGL ES 3.1 support

### DIFF
--- a/imgui/integrations/cocos2d.py
+++ b/imgui/integrations/cocos2d.py
@@ -8,6 +8,7 @@ import imgui
 from .import compute_fb_scale
 from .pyglet import PygletMixin
 from .opengl import FixedPipelineRenderer
+from .openglES import FixedPipelineRenderer
 
 
 class ImguiLayer(PygletMixin, cocos.layer.Layer):

--- a/imgui/integrations/glfw.py
+++ b/imgui/integrations/glfw.py
@@ -5,7 +5,11 @@ import glfw
 import imgui
 
 from . import compute_fb_scale
+
 from .opengl import ProgrammablePipelineRenderer
+from .openglES import ProgrammablePipelineRenderer
+
+
 
 class GlfwRenderer(ProgrammablePipelineRenderer):
     def __init__(self, window, attach_callbacks:bool=True):

--- a/imgui/integrations/openglES.py
+++ b/imgui/integrations/openglES.py
@@ -1,0 +1,425 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
+import OpenGL.GL as gl
+import imgui
+import ctypes
+
+from .base import BaseOpenGLRenderer
+
+
+class ProgrammablePipelineRenderer(BaseOpenGLRenderer):
+    """Basic OpenGL integration base class."""
+
+    VERTEX_SHADER_SRC = """
+    #version 310 es
+
+    uniform mat4 ProjMtx;
+    in vec2 Position;
+    in vec2 UV;
+    in vec4 Color;
+    out vec2 Frag_UV;
+    out vec4 Frag_Color;
+
+    void main() {
+        Frag_UV = UV;
+        Frag_Color = Color;
+
+        gl_Position = ProjMtx * vec4(Position.xy, 0, 1);
+    }
+    """
+
+    FRAGMENT_SHADER_SRC = """
+    #version 310 es
+
+    precision mediump float;
+
+    uniform sampler2D Texture;
+    in vec2 Frag_UV;
+    in vec4 Frag_Color;
+    out vec4 Out_Color;
+
+    void main() {
+        Out_Color = Frag_Color * texture(Texture, Frag_UV.st);
+    }
+    """
+
+    def __init__(self):
+        self._shader_handle = None
+        self._vert_handle = None
+        self._fragment_handle = None
+
+        self._attrib_location_tex = None
+        self._attrib_proj_mtx = None
+        self._attrib_location_position = None
+        self._attrib_location_uv = None
+        self._attrib_location_color = None
+
+        self._vbo_handle = None
+        self._elements_handle = None
+        self._vao_handle = None
+
+        super(ProgrammablePipelineRenderer, self).__init__()
+
+    def refresh_font_texture(self):
+        # save texture state
+        last_texture = gl.glGetIntegerv(gl.GL_TEXTURE_BINDING_2D)
+
+        width, height, pixels = self.io.fonts.get_tex_data_as_rgba32()
+
+        if self._font_texture is not None:
+            gl.glDeleteTextures([self._font_texture])
+
+        self._font_texture = gl.glGenTextures(1)
+
+        gl.glBindTexture(gl.GL_TEXTURE_2D, self._font_texture)
+        gl.glTexParameteri(gl.GL_TEXTURE_2D, gl.GL_TEXTURE_MIN_FILTER, gl.GL_LINEAR)
+        gl.glTexParameteri(gl.GL_TEXTURE_2D, gl.GL_TEXTURE_MAG_FILTER, gl.GL_LINEAR)
+        gl.glTexImage2D(gl.GL_TEXTURE_2D, 0, gl.GL_RGBA, width, height, 0, gl.GL_RGBA, gl.GL_UNSIGNED_BYTE, pixels)
+
+        self.io.fonts.texture_id = self._font_texture
+        gl.glBindTexture(gl.GL_TEXTURE_2D, last_texture)
+        self.io.fonts.clear_tex_data()
+
+    def _create_device_objects(self):
+        # save state
+        last_texture = gl.glGetIntegerv(gl.GL_TEXTURE_BINDING_2D)
+        last_array_buffer = gl.glGetIntegerv(gl.GL_ARRAY_BUFFER_BINDING)
+
+        last_vertex_array = gl.glGetIntegerv(gl.GL_VERTEX_ARRAY_BINDING)
+
+        self._shader_handle = gl.glCreateProgram()
+        # note: no need to store shader parts handles after linking
+        vertex_shader = gl.glCreateShader(gl.GL_VERTEX_SHADER)
+        fragment_shader = gl.glCreateShader(gl.GL_FRAGMENT_SHADER)
+
+        gl.glShaderSource(vertex_shader, self.VERTEX_SHADER_SRC)
+        gl.glShaderSource(fragment_shader, self.FRAGMENT_SHADER_SRC)
+        gl.glCompileShader(vertex_shader)
+        gl.glCompileShader(fragment_shader)
+
+        gl.glAttachShader(self._shader_handle, vertex_shader)
+        gl.glAttachShader(self._shader_handle, fragment_shader)
+
+        gl.glLinkProgram(self._shader_handle)
+
+        # note: after linking shaders can be removed
+        gl.glDeleteShader(vertex_shader)
+        gl.glDeleteShader(fragment_shader)
+
+        self._attrib_location_tex = gl.glGetUniformLocation(self._shader_handle, "Texture")
+        self._attrib_proj_mtx = gl.glGetUniformLocation(self._shader_handle, "ProjMtx")
+        self._attrib_location_position = gl.glGetAttribLocation(self._shader_handle, "Position")
+        self._attrib_location_uv = gl.glGetAttribLocation(self._shader_handle, "UV")
+        self._attrib_location_color = gl.glGetAttribLocation(self._shader_handle, "Color")
+
+        self._vbo_handle = gl.glGenBuffers(1)
+        self._elements_handle = gl.glGenBuffers(1)
+
+        self._vao_handle = gl.glGenVertexArrays(1)
+        gl.glBindVertexArray(self._vao_handle)
+        gl.glBindBuffer(gl.GL_ARRAY_BUFFER, self._vbo_handle)
+
+        gl.glEnableVertexAttribArray(self._attrib_location_position)
+        gl.glEnableVertexAttribArray(self._attrib_location_uv)
+        gl.glEnableVertexAttribArray(self._attrib_location_color)
+
+        gl.glVertexAttribPointer(self._attrib_location_position, 2, gl.GL_FLOAT, gl.GL_FALSE, imgui.VERTEX_SIZE, ctypes.c_void_p(imgui.VERTEX_BUFFER_POS_OFFSET))
+        gl.glVertexAttribPointer(self._attrib_location_uv, 2, gl.GL_FLOAT, gl.GL_FALSE, imgui.VERTEX_SIZE, ctypes.c_void_p(imgui.VERTEX_BUFFER_UV_OFFSET))
+        gl.glVertexAttribPointer(self._attrib_location_color, 4, gl.GL_UNSIGNED_BYTE, gl.GL_TRUE, imgui.VERTEX_SIZE, ctypes.c_void_p(imgui.VERTEX_BUFFER_COL_OFFSET))
+
+        # restore state
+        gl.glBindTexture(gl.GL_TEXTURE_2D, last_texture)
+        gl.glBindBuffer(gl.GL_ARRAY_BUFFER, last_array_buffer)
+        gl.glBindVertexArray(last_vertex_array)
+
+    def render(self, draw_data):
+        # perf: local for faster access
+        io = self.io
+
+        display_width, display_height = io.display_size
+        fb_width = int(display_width * io.display_fb_scale[0])
+        fb_height = int(display_height * io.display_fb_scale[1])
+
+        if fb_width == 0 or fb_height == 0:
+            return
+
+        draw_data.scale_clip_rects(*io.display_fb_scale)
+
+        # backup GL state
+        # todo: provide cleaner version of this backup-restore code
+        common_gl_state_tuple = get_common_gl_state()
+        last_program = gl.glGetIntegerv(gl.GL_CURRENT_PROGRAM)
+        last_active_texture = gl.glGetIntegerv(gl.GL_ACTIVE_TEXTURE)
+        last_array_buffer = gl.glGetIntegerv(gl.GL_ARRAY_BUFFER_BINDING)
+        last_element_array_buffer = gl.glGetIntegerv(gl.GL_ELEMENT_ARRAY_BUFFER_BINDING)
+        last_vertex_array = gl.glGetIntegerv(gl.GL_VERTEX_ARRAY_BINDING)
+
+        gl.glEnable(gl.GL_BLEND)
+        gl.glBlendEquation(gl.GL_FUNC_ADD)
+        gl.glBlendFunc(gl.GL_SRC_ALPHA, gl.GL_ONE_MINUS_SRC_ALPHA)
+        gl.glDisable(gl.GL_CULL_FACE)
+        gl.glDisable(gl.GL_DEPTH_TEST)
+        gl.glEnable(gl.GL_SCISSOR_TEST)
+        gl.glActiveTexture(gl.GL_TEXTURE0)
+        gl.glDrawArrays(gl.GL_LINES, 0, 1)
+
+        gl.glViewport(0, 0, int(fb_width), int(fb_height))
+
+        ortho_projection = (ctypes.c_float * 16)(
+             2.0/display_width, 0.0,                   0.0, 0.0,
+             0.0,               2.0/-display_height,   0.0, 0.0,
+             0.0,               0.0,                  -1.0, 0.0,
+            -1.0,               1.0,                   0.0, 1.0
+        )
+
+        gl.glUseProgram(self._shader_handle)
+        gl.glUniform1i(self._attrib_location_tex, 0)
+        gl.glUniformMatrix4fv(self._attrib_proj_mtx, 1, gl.GL_FALSE, ortho_projection)
+        gl.glBindVertexArray(self._vao_handle)
+
+        for commands in draw_data.commands_lists:
+            idx_buffer_offset = 0
+
+            gl.glBindBuffer(gl.GL_ARRAY_BUFFER, self._vbo_handle)
+            # todo: check this (sizes)
+            gl.glBufferData(gl.GL_ARRAY_BUFFER, commands.vtx_buffer_size * imgui.VERTEX_SIZE, ctypes.c_void_p(commands.vtx_buffer_data), gl.GL_STREAM_DRAW)
+
+            gl.glBindBuffer(gl.GL_ELEMENT_ARRAY_BUFFER, self._elements_handle)
+            # todo: check this (sizes)
+            gl.glBufferData(gl.GL_ELEMENT_ARRAY_BUFFER, commands.idx_buffer_size * imgui.INDEX_SIZE, ctypes.c_void_p(commands.idx_buffer_data), gl.GL_STREAM_DRAW)
+
+            # todo: allow to iterate over _CmdList
+            for command in commands.commands:
+                gl.glBindTexture(gl.GL_TEXTURE_2D, command.texture_id)
+
+                # todo: use named tuple
+                x, y, z, w = command.clip_rect
+                gl.glScissor(int(x), int(fb_height - w), int(z - x), int(w - y))
+
+                if imgui.INDEX_SIZE == 2:
+                    gltype = gl.GL_UNSIGNED_SHORT
+                else:
+                    gltype = gl.GL_UNSIGNED_INT
+
+                gl.glDrawElements(gl.GL_TRIANGLES, command.elem_count, gltype, ctypes.c_void_p(idx_buffer_offset))
+
+                idx_buffer_offset += command.elem_count * imgui.INDEX_SIZE
+
+        # restore modified GL state
+        restore_common_gl_state(common_gl_state_tuple)
+
+        gl.glUseProgram(last_program)
+        gl.glActiveTexture(last_active_texture)
+        gl.glBindVertexArray(last_vertex_array)
+        gl.glBindBuffer(gl.GL_ARRAY_BUFFER, last_array_buffer)
+        gl.glBindBuffer(gl.GL_ELEMENT_ARRAY_BUFFER, last_element_array_buffer)
+
+    def _invalidate_device_objects(self):
+        if self._vao_handle > -1:
+            gl.glDeleteVertexArrays(1, [self._vao_handle])
+        if self._vbo_handle > -1:
+            gl.glDeleteBuffers(1, [self._vbo_handle])
+        if self._elements_handle > -1:
+            gl.glDeleteBuffers(1, [self._elements_handle])
+        self._vao_handle = self._vbo_handle = self._elements_handle = 0
+
+        gl.glDeleteProgram(self._shader_handle)
+        self._shader_handle = 0
+
+        if self._font_texture > -1:
+            gl.glDeleteTextures([self._font_texture])
+        self.io.fonts.texture_id = 0
+        self._font_texture = 0
+
+
+class FixedPipelineRenderer(BaseOpenGLRenderer):
+    """Basic OpenGL integration base class."""
+
+    # note: no need to override __init__
+
+    def refresh_font_texture(self):
+        # save texture state
+        # last_texture = gl.glGetIntegerv(gl.GL_TEXTURE_BINDING_2D)
+        width, height, pixels = self.io.fonts.get_tex_data_as_alpha8()
+
+        if self._font_texture is not None:
+            gl.glDeleteTextures([self._font_texture])
+
+        self._font_texture = gl.glGenTextures(1)
+        gl.glBindTexture(gl.GL_TEXTURE_2D, self._font_texture)
+        gl.glTexParameteri(gl.GL_TEXTURE_2D, gl.GL_TEXTURE_MIN_FILTER, gl.GL_LINEAR)
+        gl.glTexParameteri(gl.GL_TEXTURE_2D, gl.GL_TEXTURE_MAG_FILTER, gl.GL_LINEAR)
+        gl.glTexImage2D(gl.GL_TEXTURE_2D, 0, gl.GL_ALPHA, width, height, 0, gl.GL_ALPHA, gl.GL_UNSIGNED_BYTE, pixels)
+
+        self.io.fonts.texture_id = self._font_texture
+        # gl.glBindTexture(gl.GL_TEXTURE_2D, last_texture)
+        self.io.fonts.clear_tex_data()
+
+    def _create_device_objects(self):
+        pass
+
+    def render(self, draw_data):
+        # perf: local for faster access
+        io = self.io
+
+        display_width, display_height = io.display_size
+        fb_width = int(display_width * io.display_fb_scale[0])
+        fb_height = int(display_height * io.display_fb_scale[1])
+
+        if fb_width == 0 or fb_height == 0:
+            return
+
+        draw_data.scale_clip_rects(*io.display_fb_scale)
+
+        # note: we are using fixed pipeline for cocos2d/pyglet
+        # todo: consider porting to programmable pipeline
+        # backup gl state
+        common_gl_state_tuple = get_common_gl_state()
+
+        gl.glPushAttrib(gl.GL_ENABLE_BIT | gl.GL_COLOR_BUFFER_BIT | gl.GL_TRANSFORM_BIT)
+        gl.glEnable(gl.GL_BLEND)
+        gl.glBlendFunc(gl.GL_SRC_ALPHA, gl.GL_ONE_MINUS_SRC_ALPHA)
+        gl.glDisable(gl.GL_CULL_FACE)
+        gl.glDisable(gl.GL_DEPTH_TEST)
+        gl.glEnable(gl.GL_SCISSOR_TEST)
+        gl.glDrawArrays(gl.GL_LINES, 0, 1)
+
+        gl.glEnableClientState(gl.GL_VERTEX_ARRAY)
+        gl.glEnableClientState(gl.GL_TEXTURE_COORD_ARRAY)
+        gl.glEnableClientState(gl.GL_COLOR_ARRAY)
+        gl.glEnable(gl.GL_TEXTURE_2D)
+
+        gl.glViewport(0, 0, int(fb_width), int(fb_height))
+        gl.glMatrixMode(gl.GL_PROJECTION)
+        gl.glPushMatrix()
+        gl.glLoadIdentity()
+        gl.glOrtho(0, io.display_size.x, io.display_size.y, 0.0, -1., 1.)
+        gl.glMatrixMode(gl.GL_MODELVIEW)
+        gl.glPushMatrix()
+        gl.glLoadIdentity()
+
+        for commands in draw_data.commands_lists:
+            idx_buffer = commands.idx_buffer_data
+
+            gl.glVertexPointer(2, gl.GL_FLOAT, imgui.VERTEX_SIZE, ctypes.c_void_p(commands.vtx_buffer_data + imgui.VERTEX_BUFFER_POS_OFFSET))
+            gl.glTexCoordPointer(2, gl.GL_FLOAT, imgui.VERTEX_SIZE, ctypes.c_void_p(commands.vtx_buffer_data + imgui.VERTEX_BUFFER_UV_OFFSET))
+            gl.glColorPointer(4, gl.GL_UNSIGNED_BYTE, imgui.VERTEX_SIZE, ctypes.c_void_p(commands.vtx_buffer_data + imgui.VERTEX_BUFFER_COL_OFFSET))
+
+            for command in commands.commands:
+                gl.glBindTexture(gl.GL_TEXTURE_2D, command.texture_id)
+
+                x, y, z, w = command.clip_rect
+                gl.glScissor(int(x), int(fb_height - w), int(z - x), int(w - y))
+
+                if imgui.INDEX_SIZE == 2:
+                    gltype = gl.GL_UNSIGNED_SHORT
+                else:
+                    gltype = gl.GL_UNSIGNED_INT
+
+                gl.glDrawElements(gl.GL_TRIANGLES, command.elem_count, gltype, ctypes.c_void_p(idx_buffer))
+
+                idx_buffer += (command.elem_count * imgui.INDEX_SIZE)
+
+        restore_common_gl_state(common_gl_state_tuple)
+
+        gl.glDisableClientState(gl.GL_COLOR_ARRAY)
+        gl.glDisableClientState(gl.GL_TEXTURE_COORD_ARRAY)
+        gl.glDisableClientState(gl.GL_VERTEX_ARRAY)
+
+        gl.glMatrixMode(gl.GL_MODELVIEW)
+        gl.glPopMatrix()
+        gl.glMatrixMode(gl.GL_PROJECTION)
+        gl.glPopMatrix()
+        gl.glPopAttrib()
+
+    def _invalidate_device_objects(self):
+        if self._font_texture > -1:
+            gl.glDeleteTextures([self._font_texture])
+        self.io.fonts.texture_id = 0
+        self._font_texture = 0
+
+def get_common_gl_state():
+    """
+    Backups the current OpenGL state
+    Returns a tuple of results for glGet / glIsEnabled calls
+    NOTE: when adding more backuped state in the future,
+    make sure to update function `restore_common_gl_state`
+    """
+    last_texture = gl.glGetIntegerv(gl.GL_TEXTURE_BINDING_2D)
+    last_viewport = gl.glGetIntegerv(gl.GL_VIEWPORT)
+    last_enable_blend = gl.glIsEnabled(gl.GL_BLEND)
+    last_enable_cull_face = gl.glIsEnabled(gl.GL_CULL_FACE)
+    last_enable_depth_test = gl.glIsEnabled(gl.GL_DEPTH_TEST)
+    last_enable_scissor_test = gl.glIsEnabled(gl.GL_SCISSOR_TEST)
+    last_scissor_box = gl.glGetIntegerv(gl.GL_SCISSOR_BOX)
+    last_blend_src = gl.glGetIntegerv(gl.GL_BLEND_SRC)
+    last_blend_dst = gl.glGetIntegerv(gl.GL_BLEND_DST_RGB)
+    last_blend_dst_alpha = gl.glGetIntegerv(gl.GL_BLEND_DST_ALPHA)
+    last_blend_equation_rgb = gl. glGetIntegerv(gl.GL_BLEND_EQUATION_RGB)
+    last_blend_equation_alpha = gl.glGetIntegerv(gl.GL_BLEND_EQUATION_ALPHA)
+    
+    return (
+        last_texture,
+        last_viewport,
+        last_enable_blend,
+        last_enable_cull_face,
+        last_enable_depth_test,
+        last_enable_scissor_test,
+        last_scissor_box,
+        last_blend_src,
+        last_blend_dst,
+        last_blend_dst_alpha,
+        last_blend_equation_rgb,
+        last_blend_equation_alpha,
+    )
+
+def restore_common_gl_state(common_gl_state_tuple):
+    """
+    Takes a tuple after calling function `get_common_gl_state`,
+    to set the given OpenGL state back as it was before rendering the UI
+    """
+    (
+        last_texture,
+        last_viewport,
+        last_enable_blend,
+        last_enable_cull_face,
+        last_enable_depth_test,
+        last_enable_scissor_test,
+        last_scissor_box,
+        last_blend_src,
+        last_blend_dst,
+        last_blend_dst_alpha,
+        last_blend_equation_rgb,
+        last_blend_equation_alpha,
+    ) = common_gl_state_tuple
+
+    gl.glBindTexture(gl.GL_TEXTURE_2D, last_texture)
+    gl.glBlendEquationSeparate(last_blend_equation_rgb, last_blend_equation_alpha)
+    gl.glBlendFunc(last_blend_src, last_blend_dst)
+
+    gl.glDrawArrays(gl.GL_LINES, 0, 1)
+
+    if last_enable_blend:
+        gl.glEnable(gl.GL_BLEND)
+    else:
+        gl.glDisable(gl.GL_BLEND)
+
+    if last_enable_cull_face:
+        gl.glEnable(gl.GL_CULL_FACE)
+    else:
+        gl.glDisable(gl.GL_CULL_FACE)
+
+    if last_enable_depth_test:
+        gl.glEnable(gl.GL_DEPTH_TEST)
+    else:
+        gl.glDisable(gl.GL_DEPTH_TEST)
+
+    if last_enable_scissor_test:
+        gl.glEnable(gl.GL_SCISSOR_TEST)
+    else:
+        gl.glDisable(gl.GL_SCISSOR_TEST)
+
+
+    gl.glScissor(last_scissor_box[0], last_scissor_box[1], last_scissor_box[2], last_scissor_box[3])
+    gl.glViewport(last_viewport[0], last_viewport[1], last_viewport[2], last_viewport[3])

--- a/imgui/integrations/pygame.py
+++ b/imgui/integrations/pygame.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 from .opengl import FixedPipelineRenderer
+from .openglES import FixedPipelineRenderer
 
 import pygame
 import pygame.event

--- a/imgui/integrations/pyglet.py
+++ b/imgui/integrations/pyglet.py
@@ -11,6 +11,7 @@ import imgui
 
 from . import compute_fb_scale
 from .opengl import FixedPipelineRenderer, ProgrammablePipelineRenderer
+from .openglES import FixedPipelineRenderer, ProgrammablePipelineRenderer
 
 
 class PygletMixin(object):

--- a/imgui/integrations/sdl2.py
+++ b/imgui/integrations/sdl2.py
@@ -7,6 +7,7 @@ import imgui
 import ctypes
 
 from .opengl import ProgrammablePipelineRenderer
+from .openglES import ProgrammablePipelineRenderer
 
 
 class SDL2Renderer(ProgrammablePipelineRenderer):


### PR DESCRIPTION
So basically I added an OpenGL ES 3.1 support with pyimgui, so you can used it on a Raspberry Pi 5 or other SBCs that only support OpenGL ES.
I added a new file in integrations, called openglES.py that adapts the functions from OpenGL 3.3 to OpenGL ES 3.1 and I also added a new line to import openglES in all built-in rendering backend integrations, except for glumpy.